### PR TITLE
chore: Rename the package from gnosocial to social

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -1,4 +1,4 @@
-package gnosocial
+package social
 
 import (
 	"std"

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -1,4 +1,4 @@
-package gnosocial
+package social
 
 import (
 	"std"

--- a/realm/render.gno
+++ b/realm/render.gno
@@ -1,4 +1,4 @@
-package gnosocial
+package social
 
 import (
 	"strconv"

--- a/realm/social.gno
+++ b/realm/social.gno
@@ -1,4 +1,4 @@
-package gnosocial
+package social
 
 import (
 	"gno.land/p/demo/avl"

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -1,4 +1,4 @@
-package gnosocial
+package social
 
 import (
 	"std"

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -1,4 +1,4 @@
-package gnosocial
+package social
 
 import (
 	"std"


### PR DESCRIPTION
The Effective Gno document says ["Your package name should match the folder name."](https://github.com/gnolang/gno/blob/71b2e762b97887981d91d46d682cce2960b97c20/docs/how-to-guides/effective-gno.md?plain=1#L318) Our folder name is "social" and the import path is "r/berty/social"

![Screenshot 2024-01-15 at 11 22 02](https://github.com/gnolang/gnosocial/assets/1999543/450d580b-e75e-4d6a-b781-91dec5127829)

Therefore, this PR renames `package gnosocial` to `package social`. (Note that the boards realm [just uses `package boards`](https://github.com/gnolang/gno/blob/f6698e6aeb2919771a058b99c07ac9b9e0b7a4bd/examples/gno.land/r/demo/boards/post.gno#L1).)