### PR TITLE
Add GetThreadPosts with JSON response

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -1,11 +1,13 @@
 package social
 
 import (
+	"bytes"
 	"std"
 	"strconv"
 	"time"
 
 	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ufmt"
 )
 
 //----------------------------------------
@@ -200,4 +202,44 @@ func (post *Post) RenderInner() string {
 	str += "\n"
 	str += post.RenderPost("> ", 5)
 	return str
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (post *Post) MarshalJSON() ([]byte, error) {
+	createdAt, err := post.createdAt.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	json := new(bytes.Buffer)
+
+	json.WriteString(ufmt.Sprintf(`{"id": %d, "createdAt": %s, "n_replies": %d, "n_replies_all": %d, "parent_id": %d`,
+		uint64(post.id), string(createdAt), post.replies.Size(), post.repliesAll.Size(), uint64(post.parentID)))
+	if post.repostUser != "" {
+		json.WriteString(ufmt.Sprintf(`, "repost_user": %s`, strconv.Quote(post.repostUser.String())))
+	}
+	json.WriteString(ufmt.Sprintf(`, "body": %s}`, strconv.Quote(post.body)))
+
+	return json.Bytes(), nil
+}
+
+func getPosts(posts avl.Tree, startIndex int, endIndex int) string {
+	json := ufmt.Sprintf("{\"n_threads\": %d, \"posts\": [\n  ", posts.Size())
+
+	for i := startIndex; i < endIndex && i < posts.Size(); i++ {
+		if i > startIndex {
+			json += ",\n  "
+		}
+
+		_, postI := posts.GetByIndex(i)
+		post := postI.(*Post)
+		postJson, err := post.MarshalJSON()
+		if err != nil {
+			panic("can't get post JSON")
+		}
+		json += ufmt.Sprintf("{\"index\": %d, \"post\": %s}", i, string(postJson))
+	}
+
+	json += "]}"
+	return json
 }

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -2,6 +2,8 @@ package social
 
 import (
 	"std"
+
+	"gno.land/p/demo/ufmt"
 )
 
 // Post a message to the caller's main user posts.
@@ -91,4 +93,39 @@ func RepostThread(userPostsAddr std.Address, threadid PostID, comment string) Po
 	}
 	repost := thread.AddRepostTo(caller, comment, dstUserPosts)
 	return repost.id
+}
+
+// Get posts in a thread for a user. A thread is the sequence of posts without replies.
+// While each post has an an arbitrary id, it also has an index within the thread starting from 0.
+// Limit the response to posts from startIndex up to (not including) endIndex within the thread.
+// If threadID is 0 then return the user's top-level posts. (Like render args "user".)
+// If threadID is X and replyID is 0, then return the posts (without replies) in that thread. (Like render args "user/2".)
+// If threadID is X and replyID is Y, then return the posts in the thread starting with replyID. (Like render args "user/2/5".)
+// The response includes reposts by this user (only if threadID is 0), but not messages of other
+// users that are being followed. The response is a JSON string.
+func GetThreadPosts(userPostsAddr std.Address, threadID int, replyID int, startIndex int, endIndex int) string {
+	userPosts := getUserPosts(userPostsAddr)
+	if userPosts == nil {
+		panic("posts for userPostsAddr do not exist")
+	}
+
+	if threadID <= 0 {
+		return getPosts(userPosts.threads, startIndex, endIndex)
+	}
+
+	thread := userPosts.GetThread(PostID(threadID))
+	if thread == nil {
+		panic(ufmt.Sprintf("thread does not exist with id %d", threadID))
+	}
+
+	if replyID <= 0 {
+		return getPosts(thread.replies, startIndex, endIndex)
+	} else {
+		reply := thread.GetReply(PostID(replyID))
+		if reply == nil {
+			panic(ufmt.Sprintf("reply does not exist with id %d in thread with id %d", replyID, threadID))
+		}
+
+		return getPosts(reply.replies, startIndex, endIndex)
+	}
 }

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -109,7 +109,7 @@ func GetThreadPosts(userPostsAddr std.Address, threadID int, replyID int, startI
 		panic("posts for userPostsAddr do not exist")
 	}
 
-	if threadID <= 0 {
+	if threadID == 0 {
 		return getPosts(userPosts.threads, startIndex, endIndex)
 	}
 
@@ -118,7 +118,7 @@ func GetThreadPosts(userPostsAddr std.Address, threadID int, replyID int, startI
 		panic(ufmt.Sprintf("thread does not exist with id %d", threadID))
 	}
 
-	if replyID <= 0 {
+	if replyID == 0 {
 		return getPosts(thread.replies, startIndex, endIndex)
 	} else {
 		reply := thread.GetReply(PostID(replyID))


### PR DESCRIPTION
Add public function GetThreadPosts with supporting private functions. Example response:
```
{"n_threads": 2, "posts": [
  {"index": 0, "post": {"id": 1, "createdAt": "2024-02-15T17:37:28Z", "n_replies": 3, "n_replies_all": 5, "parent_id": 0, "body": "My second post"}},
  {"index": 1, "post": {"id": 3, "createdAt": "2024-02-15T17:37:28Z", "n_replies": 0, "n_replies_all": 0, "parent_id": 0, "body": "My third post"}}]}
```