### PR TITLE
Display account balance

### DIFF
--- a/mobile/app/(root)/settings.tsx
+++ b/mobile/app/(root)/settings.tsx
@@ -7,9 +7,9 @@ import Button from "@gno/components/button";
 import useOnboarding from "@gno/hooks/use-onboarding";
 import { KeyInfo } from "@gno/api/gnonativetypes_pb";
 import Layout from "@gno/components/layout";
-import Text from "@gno/components/text";
 import Spacer from "@gno/components/spacer";
 import { LoadingModal } from "@gno/components/loading";
+import { AccountBalance } from "@gno/components/settings";
 
 export default function Page() {
   const [activeAccount, setActiveAccount] = useState<KeyInfo | undefined>(undefined);
@@ -62,12 +62,7 @@ export default function Page() {
       <Layout.Container>
         <Layout.Body>
           <>
-            <View>
-              <Text.HeaderSubtitle>Active Account:</Text.HeaderSubtitle>
-              <Text.Body style={{ fontSize: 14 }}>
-                {activeAccount ? JSON.stringify(activeAccount) : "No active account."}
-              </Text.Body>
-            </View>
+            <AccountBalance activeAccount={activeAccount} />
 
             <View>
               <Button.TouchableOpacity

--- a/mobile/components/settings/account/account-balance.tsx
+++ b/mobile/components/settings/account/account-balance.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import { KeyInfo } from "@gno/api/gnonativetypes_pb";
+import Text from "@gno/components/text";
+import { useGno } from "@gno/hooks/use-gno";
+
+interface Props {
+  activeAccount: KeyInfo | undefined;
+}
+
+export function AccountBalance({ activeAccount }: Props) {
+  const [address, setAddress] = useState<string | undefined>(undefined);
+  const [balance, setBalance] = useState<string | undefined>(undefined);
+
+  const gno = useGno();
+
+  useEffect(() => {
+    if (!activeAccount) {
+      return;
+    }
+    gno.addressToBech32(activeAccount.address).then((address) => {
+      setAddress(address);
+    });
+    gno.queryAccount(activeAccount.address).then((balance) => {
+      setBalance(JSON.stringify(balance.accountInfo?.coins));
+    }).catch((error) => {
+     setBalance(JSON.stringify(error));
+    });
+  }, [activeAccount]);
+
+  if (!activeAccount) {
+    return (
+      <>
+        <Text.HeaderSubtitle>Active Account:</Text.HeaderSubtitle>
+        <Text.Body style={{ fontSize: 14 }}>No active account.</Text.Body>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Text.HeaderSubtitle>Active Account</Text.HeaderSubtitle>
+      <Text.Body>{activeAccount.name}</Text.Body>
+      <Text.Subheadline>Address:</Text.Subheadline>
+      <Text.Body>{address}</Text.Body>
+      <Text.Subheadline>Balance:</Text.Subheadline>
+      <Text.Body>{balance}</Text.Body>
+    </>
+  );
+}

--- a/mobile/components/settings/account/account-balance.tsx
+++ b/mobile/components/settings/account/account-balance.tsx
@@ -21,7 +21,8 @@ export function AccountBalance({ activeAccount }: Props) {
       setAddress(address);
     });
     gno.queryAccount(activeAccount.address).then((balance) => {
-      setBalance(JSON.stringify(balance.accountInfo?.coins));
+      setBalance(balance.accountInfo?.coins.reduce(
+        (acc, coin) => acc + coin.amount.toString() + coin.denom + " ", ""));
     }).catch((error) => {
      setBalance(JSON.stringify(error));
     });

--- a/mobile/components/settings/index.ts
+++ b/mobile/components/settings/index.ts
@@ -1,0 +1,3 @@
+import { AccountBalance } from "./account/account-balance";
+
+export { AccountBalance };


### PR DESCRIPTION
This pull request adds a new feature to display the account balance. It includes changes to the `Config` page, adding the `AccountBalance` component, and updating the UI to show the active account's name, address, and balance.

<img width="200" src="https://github.com/gnolang/gnosocial/assets/689440/5c760ebd-477f-4f2e-b195-e6eb7715f6ca" />
