### PR TITLE
chore: In UserPosts.AddThread, remove unneeded arg creator

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -25,7 +25,7 @@ func PostMessage(body string) PostID {
 		gUserPostsByAddress.Set(caller.String(), userPosts)
 	}
 
-	thread := userPosts.AddThread(caller, body)
+	thread := userPosts.AddThread(body)
 	return thread.id
 }
 

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -38,10 +38,11 @@ func (userPosts *UserPosts) GetThread(pid PostID) *Post {
 	return postI.(*Post)
 }
 
-func (userPosts *UserPosts) AddThread(creator std.Address, body string) *Post {
+// Add a new top-level thread to the userPosts. Return the new Post.
+func (userPosts *UserPosts) AddThread(body string) *Post {
 	pid := userPosts.incGetPostID()
 	pidkey := postIDKey(pid)
-	thread := newPost(userPosts, pid, creator, body, pid, 0, "")
+	thread := newPost(userPosts, pid, userPosts.userAddr, body, pid, 0, "")
 	userPosts.threads.Set(pidkey, thread)
 	return thread
 }


### PR DESCRIPTION
The UserPosts method `AddThread` adds a posts to start a new top-level thread. This can only be done by a user to their own list of user posts. Indeed, there is only one place that calls `AddThread` and the creator is the same as the caller. Therefore, the `creator` arg to `AddThread` is redundant and not needed.