### PR TITLE
chore: Add debugNow()

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -10,6 +10,8 @@ import (
 	"gno.land/p/demo/ufmt"
 )
 
+var debugNowOffset time.Duration
+
 //----------------------------------------
 // Post
 
@@ -49,7 +51,7 @@ func newPost(userPosts *UserPosts, id PostID, creator std.Address, body string, 
 		threadID:   threadID,
 		parentID:   parentID,
 		repostUser: repostUser,
-		createdAt:  time.Now(),
+		createdAt:  debugNow(),
 	}
 }
 
@@ -242,4 +244,15 @@ func getPosts(posts avl.Tree, startIndex int, endIndex int) string {
 
 	json += "]}"
 	return json
+}
+
+// Until the problem explained in https://github.com/gnolang/gno/issues/1509
+// is solved, we need post timestamps to be different on reload. This
+// calls Time.Now() and adds an offset which increases by one minute on each call.
+// Therefore, in "normal" operation (before reload) the times are close to the
+// expected value. After reload, all times will be the time of reload, increasing by
+// one minute each, which is not ideal but at least they are different and in order.
+func debugNow() time.Time {
+	debugNowOffset += time.Minute
+	return time.Now().Add(debugNowOffset)
 }


### PR DESCRIPTION
See the doc comment for debugNow(). Use it instead of time.Now() to get the post's timestamp. When issue https://github.com/gnolang/gno/issues/1509 is resolved, we can revert this.