### PR TITLE
Fix gasWanted value in PostMessage function

### DIFF
--- a/mobile/app/(root)/post.tsx
+++ b/mobile/app/(root)/post.tsx
@@ -36,7 +36,7 @@ export default function Page() {
     setError(undefined);
     try {
       const gasFee = "1000000ugnot";
-      const gasWanted = 2000000;
+      const gasWanted = 10000000;
       const args: Array<string> = [postContent];
       for await (const response of await gno.call("gno.land/r/berty/social", "PostMessage", args, gasFee, gasWanted)) {
         console.log("response: ", response);


### PR DESCRIPTION
This pull request fixes the gasWanted value in the PostMessage function in order to set it to 10,000,000 instead of 2,000,000. This ensures that the function has enough gas to execute properly.