### PR TITLE
chore: Use global postsCtr to help sorting by timestamp

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -166,9 +166,8 @@ func GetThreadPosts(userPostsAddr std.Address, threadID int, replyID int, startI
 
 // Get home posts for a user, which are the user's top-level posts plus all posts of all
 // users being followed.
-// The response is a map of postTime/postID -> *Post where the post time as a string like
-// "2024-02-26 13:02:46 +0000 UTC m=+1708952566.000000001". The key includes the postID because
-// there may be multiple posts with the same timestamp. (The avl.Tree sorts by the post time.)
+// The response is a map of postID -> *Post. The avl.Tree sorts by the post ID which is
+// unique for every post and increases in time.
 func GetHomePosts(userPostsAddr std.Address) *avl.Tree {
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
@@ -176,11 +175,10 @@ func GetHomePosts(userPostsAddr std.Address) *avl.Tree {
 	}
 
 	// TODO: This computes all home posts on each call. Can this be more efficient?
-	allPosts := avl.Tree{} // postTime -> *Post
+	allPosts := avl.Tree{} // postID -> *Post
 	userPosts.threads.Iterate("", "", func(id string, postI interface{}) bool {
 		post := postI.(*Post)
-		createdAtString := post.createdAt.String()
-		allPosts.Set(createdAtString+"/"+id, post)
+		allPosts.Set(id, post)
 		return false
 	})
 	userPosts.addFollowedPosts(&allPosts, time.Time{}, debugNow())

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -166,9 +166,9 @@ func GetThreadPosts(userPostsAddr std.Address, threadID int, replyID int, startI
 
 // Get home posts for a user, which are the user's top-level posts plus all posts of all
 // users being followed.
-// The response is a map of postTime -> []*Post where the post time as a string like
-// "2024-02-26 13:02:46 +0000 UTC m=+1708952566.000000001". (The avl.Tree sorts by the post time.)
-// The value is an array of *Post because there can be multiple posts with the same time.
+// The response is a map of postTime/postID -> *Post where the post time as a string like
+// "2024-02-26 13:02:46 +0000 UTC m=+1708952566.000000001". The key includes the postID because
+// there may be multiple posts with the same timestamp. (The avl.Tree sorts by the post time.)
 func GetHomePosts(userPostsAddr std.Address) *avl.Tree {
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
@@ -176,17 +176,11 @@ func GetHomePosts(userPostsAddr std.Address) *avl.Tree {
 	}
 
 	// TODO: This computes all home posts on each call. Can this be more efficient?
-	allPosts := avl.Tree{} // postTime -> []*Post
+	allPosts := avl.Tree{} // postTime -> *Post
 	userPosts.threads.Iterate("", "", func(id string, postI interface{}) bool {
 		post := postI.(*Post)
-		posts := []*Post{}
 		createdAtString := post.createdAt.String()
-		postsI, exists := allPosts.Get(createdAtString)
-		if exists {
-			// There are multiple posts with the same time.
-			posts = postsI.([]*Post)
-		}
-		allPosts.Set(createdAtString, append(posts, post))
+		allPosts.Set(createdAtString+"/"+id, post)
 		return false
 	})
 	userPosts.addFollowedPosts(&allPosts, time.Time{}, debugNow())
@@ -203,20 +197,16 @@ func GetJsonHomePosts(userPostsAddr std.Address, startIndex int, endIndex int) s
 	allPosts := GetHomePosts(userPostsAddr)
 	postsJson := ""
 	for i := startIndex; i < endIndex && i < allPosts.Size(); i++ {
-		_, postsI := allPosts.GetByIndex(i)
-		for _, post := range postsI.([]*Post) {
-			if postsJson != "" {
-				postsJson += ",\n  "
-			}
-
-			postJson, err := post.MarshalJSON()
-			if err != nil {
-				panic("can't get post JSON")
-			}
-			// TODO: If postsI has multiple posts (at the same time), the i can be repeated. Also,
-			//   if requested 10 posts from index 0 to 9, then this would return more than 10 posts. Is that a problem?
-			postsJson += ufmt.Sprintf("{\"index\": %d, \"post\": %s}", i, string(postJson))
+		_, postI := allPosts.GetByIndex(i)
+		if postsJson != "" {
+			postsJson += ",\n  "
 		}
+
+		postJson, err := postI.(*Post).MarshalJSON()
+		if err != nil {
+			panic("can't get post JSON")
+		}
+		postsJson += ufmt.Sprintf("{\"index\": %d, \"post\": %s}", i, string(postJson))
 	}
 
 	return ufmt.Sprintf("{\"n_posts\": %d, \"posts\": [\n  %s]}", allPosts.Size(), postsJson)

--- a/realm/social.gno
+++ b/realm/social.gno
@@ -6,4 +6,5 @@ import (
 
 var (
 	gUserPostsByAddress avl.Tree // user's std.Address -> *UserPosts
+	postsCtr            uint64   // increments Post.id globally
 )

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -102,7 +102,7 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	allPosts := avl.Tree{} // postTime -> *Post
 	userPosts.threads.Iterate("", "", func(id string, postI interface{}) bool {
 		post := postI.(*Post)
-		allPosts.Set(post.createdAt.String(), post)
+		allPosts.Set(id, post)
 		return false
 	})
 	if includeFollowed {
@@ -202,9 +202,8 @@ func (userPosts *UserPosts) GetUnfollowFormURL(followedAddr std.Address) string 
 
 // Scan userPosts.following and for all posts from all followed users from startTime up to (not including) endTime.
 // if startTime.IsZero(), then use the FollowingInfo startedFollowingAt time.
-// Add the posts to the followedPosts map of postTime/postID -> *Post where the post time as a string like
-// "2024-02-26 13:02:46 +0000 UTC m=+1708952566.000000001". The key includes the postID because
-// there may be multiple posts with the same timestamp. (The avl.Tree sorts by the post time.)
+// Add the posts to the followedPosts map of postID -> *Post. The avl.Tree sorts by the post ID which is
+// unique for every post and increases in time.
 func (userPosts *UserPosts) addFollowedPosts(followedPosts *avl.Tree, startTime time.Time, endTime time.Time) {
 	userPosts.following.Iterate("", "", func(followedAddr string, infoI interface{}) bool {
 		followedUserPosts := getUserPosts(std.Address(followedAddr))
@@ -228,8 +227,7 @@ func (userPosts *UserPosts) addFollowedPosts(followedPosts *avl.Tree, startTime 
 				return true
 			}
 
-			createdAtString := post.createdAt.String()
-			followedPosts.Set(createdAtString+"/"+id, post)
+			followedPosts.Set(id, post)
 			return false
 		})
 

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -102,18 +102,16 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	allPosts := avl.Tree{} // postTime -> *Post
 	userPosts.threads.Iterate("", "", func(id string, postI interface{}) bool {
 		post := postI.(*Post)
-		allPosts.Set(post.createdAt.String(), []*Post{post})
+		allPosts.Set(post.createdAt.String(), post)
 		return false
 	})
 	if includeFollowed {
 		userPosts.addFollowedPosts(&allPosts, time.Time{}, debugNow())
 	}
 
-	allPosts.Iterate("", "", func(key string, postsI interface{}) bool {
-		for _, post := range postsI.([]*Post) {
-			str += "----------------------------------------\n"
-			str += post.RenderSummary() + "\n"
-		}
+	allPosts.Iterate("", "", func(key string, postI interface{}) bool {
+		str += "----------------------------------------\n"
+		str += postI.(*Post).RenderSummary() + "\n"
 		return false
 	})
 
@@ -204,9 +202,9 @@ func (userPosts *UserPosts) GetUnfollowFormURL(followedAddr std.Address) string 
 
 // Scan userPosts.following and for all posts from all followed users from startTime up to (not including) endTime.
 // if startTime.IsZero(), then use the FollowingInfo startedFollowingAt time.
-// Add the posts to the followedPosts map of postTime -> []*Post where the post time as a string like
-// "2024-02-26 13:02:46 +0000 UTC m=+1708952566.000000001". (The avl.Tree sorts by the post time.)
-// The value is an array of *Post because there can be multiple posts with the same time.
+// Add the posts to the followedPosts map of postTime/postID -> *Post where the post time as a string like
+// "2024-02-26 13:02:46 +0000 UTC m=+1708952566.000000001". The key includes the postID because
+// there may be multiple posts with the same timestamp. (The avl.Tree sorts by the post time.)
 func (userPosts *UserPosts) addFollowedPosts(followedPosts *avl.Tree, startTime time.Time, endTime time.Time) {
 	userPosts.following.Iterate("", "", func(followedAddr string, infoI interface{}) bool {
 		followedUserPosts := getUserPosts(std.Address(followedAddr))
@@ -230,14 +228,8 @@ func (userPosts *UserPosts) addFollowedPosts(followedPosts *avl.Tree, startTime 
 				return true
 			}
 
-			posts := []*Post{}
 			createdAtString := post.createdAt.String()
-			postsI, exists := followedPosts.Get(createdAtString)
-			if exists {
-				// There are multiple posts with the same time.
-				posts = postsI.([]*Post)
-			}
-			followedPosts.Set(createdAtString, append(posts, post))
+			followedPosts.Set(createdAtString+"/"+id, post)
 			return false
 		})
 

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -23,7 +23,6 @@ type UserPosts struct {
 	url       string
 	userAddr  std.Address
 	threads   avl.Tree // Post.id -> *Post
-	postsCtr  uint64   // increments Post.id
 	followers avl.Tree // std.Address -> ""
 	following avl.Tree // std.Address -> *FollowingInfo
 }
@@ -176,8 +175,8 @@ func (userPosts *UserPosts) RenderFollowing() string {
 }
 
 func (userPosts *UserPosts) incGetPostID() PostID {
-	userPosts.postsCtr++
-	return PostID(userPosts.postsCtr)
+	postsCtr++
+	return PostID(postsCtr)
 }
 
 func (userPosts *UserPosts) GetURLFromThreadAndReplyID(threadID, replyID PostID) string {


### PR DESCRIPTION
In the current `GetJsonHomePosts`, [a comment](https://github.com/gnolang/gnosocial/blob/7348d269c00e89829180cf039c8d5f30d1663671/realm/public.gno#L216-L217) points out that there can be multiple posts with the same timestamp. This can be resolved if the Post ID is globally unique for the whole GnoSocial realm. (Currently, the post ID is only unique for each user.) This PR implements this with two commits:
1. Move `postsCtr` from the `UserPosts` object to a global variable for the realm.
2. Now, we can simplify the avl.Tree in `GetHomePosts` and the related `addFollowedPosts`. The avl.Tree key is postTime/postID. Because the postID is globally unique, this creates a unique key even if the postTime is the same for multiple posts. The keys are still sorted by postTime. The problem mentioned in the comment is resolved.