### PR TITLE
fix: Access the User struct Name and Address without the getter method

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -105,7 +105,7 @@ func GetUsers() *avl.Tree {
 	gUserPostsByAddress.Iterate("", "", func(addr string, userPostsI interface{}) bool {
 		if user := users.GetUserByAddress(std.Address(addr)); user != nil {
 			// allUsers will be sorted by the name key.
-			allUsers.Set(user.Name(), addr)
+			allUsers.Set(user.Name, addr)
 		}
 		return false
 	})

--- a/realm/render.gno
+++ b/realm/render.gno
@@ -17,7 +17,7 @@ func Render(path string) string {
 		names := []string{}
 		gUserPostsByAddress.Iterate("", "", func(key string, value interface{}) bool {
 			if user := users.GetUserByAddress(std.Address(key)); user != nil {
-				names = append(names, user.Name())
+				names = append(names, user.Name)
 			}
 			return false
 		})
@@ -37,7 +37,7 @@ func Render(path string) string {
 			return "Unknown user: " + path
 		}
 
-		userPosts := getUserPosts(user.Address())
+		userPosts := getUserPosts(user.Address)
 		if userPosts == nil {
 			return "No posts by: " + path
 		}
@@ -49,7 +49,7 @@ func Render(path string) string {
 		if user == nil {
 			return "Unknown user: " + name
 		}
-		userPosts := getUserPosts(user.Address())
+		userPosts := getUserPosts(user.Address)
 		if userPosts == nil {
 			return "No posts by: " + name
 		}
@@ -82,7 +82,7 @@ func Render(path string) string {
 		if user == nil {
 			return "Unknown user: " + name
 		}
-		userPosts := getUserPosts(user.Address())
+		userPosts := getUserPosts(user.Address)
 		if userPosts == nil {
 			return "No posts by: " + name
 		}

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -92,8 +92,8 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	following := "Following " + strconv.Itoa(userPosts.following.Size())
 	user := users.GetUserByAddress(userPosts.userAddr)
 	if user != nil {
-		followers = "[" + followers + "](/r/berty/social:" + user.Name() + "/followers)"
-		following = "[" + following + "](/r/berty/social:" + user.Name() + "/following)"
+		followers = "[" + followers + "](/r/berty/social:" + user.Name + "/followers)"
+		following = "[" + following + "](/r/berty/social:" + user.Name + "/following)"
 	}
 	str += followers + " &nbsp;" + following + "\n\n"
 
@@ -122,7 +122,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 	str := ""
 	user := users.GetUserByAddress(userPosts.userAddr)
 	if user != nil {
-		str += "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ") "
+		str += "[@" + user.Name + "](/r/berty/social:" + user.Name + ") "
 	}
 	str += "Followers\n\n"
 
@@ -130,7 +130,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 	names := []string{}
 	userPosts.followers.Iterate("", "", func(key string, value interface{}) bool {
 		if user := users.GetUserByAddress(std.Address(key)); user != nil {
-			names = append(names, user.Name())
+			names = append(names, user.Name)
 		}
 		return false
 	})
@@ -146,7 +146,7 @@ func (userPosts *UserPosts) RenderFollowing() string {
 	str := ""
 	user := users.GetUserByAddress(userPosts.userAddr)
 	if user != nil {
-		str += "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ") "
+		str += "[@" + user.Name + "](/r/berty/social:" + user.Name + ") "
 	}
 	str += "Following\n\n"
 
@@ -155,7 +155,7 @@ func (userPosts *UserPosts) RenderFollowing() string {
 	userPosts.following.Iterate("", "", func(addr string, infoI interface{}) bool {
 		info := infoI.(*FollowingInfo)
 		if user := users.GetUserByAddress(std.Address(addr)); user != nil {
-			nameAddrs = append(nameAddrs, user.Name()+"/"+addr+"/"+info.startedFollowingAt.Format("2006-01-02"))
+			nameAddrs = append(nameAddrs, user.Name+"/"+addr+"/"+info.startedFollowingAt.Format("2006-01-02"))
 		}
 		return false
 	})

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -64,7 +64,7 @@ func displayAddressMD(addr std.Address) string {
 	if user == nil {
 		return "[" + addr.String() + "](/r/demo/users:" + addr.String() + ")"
 	} else {
-		return "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ")"
+		return "[@" + user.Name + "](/r/berty/social:" + user.Name + ")"
 	}
 }
 
@@ -73,6 +73,6 @@ func usernameOf(addr std.Address) string {
 	if user == nil {
 		return ""
 	} else {
-		return user.Name()
+		return user.Name
 	}
 }


### PR DESCRIPTION
As explained in [this comment](https://github.com/gnolang/gno/pull/1433#issuecomment-1973049786), a recent PR makes a breaking change to the API for r/demo/users. This PR updates r/berty/social to use the new API. This is necessary if you install the latest gnodev with the new API.