### PR TITLE
chore: Add GetJsonUserByAddress

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -2,6 +2,7 @@ package social
 
 import (
 	"std"
+	"strconv"
 	"time"
 
 	"gno.land/p/demo/avl"
@@ -250,4 +251,17 @@ func Unfollow(followedAddr std.Address) {
 	}
 
 	userPosts.Unfollow(followedAddr)
+}
+
+// Call users.GetUserByAddress and return the result as JSON, or "" if not found.
+// (This is a temporary utility until gno.land supports returning structured data directly.)
+func GetJsonUserByAddress(addr std.Address) string {
+	user := users.GetUserByAddress(addr)
+	if user == nil {
+		return ""
+	}
+
+	return ufmt.Sprintf(
+		"{\"address\": \"%s\", \"name\": \"%s\", \"profile\": %s, \"number\": %d, \"invites\": %d, \"inviter\": \"%s\"}",
+		user.Address.String(), user.Name, strconv.Quote(user.Profile), user.Number, user.Invites, user.Inviter.String())
 }


### PR DESCRIPTION
GnoSocial needs the information from `users.GetUserByAddress`, but calling this remotely returns the usual result that's difficult to process. This PR adds the utility function `GetJsonUserByAddress` to return the `User` object as JSON. We can remove this when Gno.land is updated to return usable objects  for remote function calls.