### PR TITLE
feat: add list users by prefix ListJsonUsersByPrefix 

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -22,13 +22,7 @@ func PostMessage(body string) PostID {
 		panic("please register")
 	}
 
-	userPosts := getUserPosts(caller)
-	if userPosts == nil {
-		url := "/r/berty/social:" + name
-		userPosts = newUserPosts(url, caller)
-		gUserPostsByAddress.Set(caller.String(), userPosts)
-	}
-
+	userPosts := getOrCreateUserPosts(caller, name)
 	thread := userPosts.AddThread(body)
 	return thread.id
 }
@@ -77,12 +71,7 @@ func RepostThread(userPostsAddr std.Address, threadid PostID, comment string) Po
 	if name == "" {
 		panic("please register")
 	}
-	dstUserPosts := getUserPosts(caller)
-	if dstUserPosts == nil {
-		url := "/r/berty/social:" + name
-		dstUserPosts = newUserPosts(url, caller)
-		gUserPostsByAddress.Set(caller.String(), dstUserPosts)
-	}
+	dstUserPosts := getOrCreateUserPosts(caller, name)
 
 	if userPostsAddr == caller {
 		panic("Cannot repost a user's own message")
@@ -224,14 +213,8 @@ func Follow(followedAddr std.Address) {
 		panic("you can't follow yourself")
 	}
 
-	userPosts := getUserPosts(caller)
-	if userPosts == nil {
-		// A user can follow someone before doing any posts, so create the UserPosts.
-		url := "/r/berty/social:" + name
-		userPosts = newUserPosts(url, caller)
-		gUserPostsByAddress.Set(caller.String(), userPosts)
-	}
-
+	// A user can follow someone before doing any posts, so create the UserPosts if needed.
+	userPosts := getOrCreateUserPosts(caller, name)
 	userPosts.Follow(followedAddr)
 }
 

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -248,3 +248,52 @@ func GetJsonUserByAddress(addr std.Address) string {
 		"{\"address\": \"%s\", \"name\": \"%s\", \"profile\": %s, \"number\": %d, \"invites\": %d, \"inviter\": \"%s\"}",
 		user.Address.String(), user.Name, strconv.Quote(user.Profile), user.Number, user.Invites, user.Inviter.String())
 }
+
+// TODO: This is a temporary copy. Remove this when they merge https://github.com/gnolang/gno/pull/1708.
+func listKeysByPrefix(tree avl.Tree, prefix string, maxResults int) []string {
+	end := ""
+	n := len(prefix)
+	// To make the end of the search, increment the final character ASCII by one.
+	for n > 0 {
+		if ascii := int(prefix[n-1]); ascii < 0xff {
+			end = prefix[0:n-1] + string(ascii+1)
+			break
+		}
+
+		// The last character is 0xff. Try the previous character.
+		n--
+	}
+
+	result := []string{}
+	tree.Iterate(prefix, end, func(key string, value interface{}) bool {
+		result = append(result, key)
+		if len(result) >= maxResults {
+			return true
+		}
+		return false
+	})
+	return result
+}
+
+// Get a list of user names starting from the given prefix. Limit the
+// number of results to maxResults.
+func ListUsersByPrefix(prefix string, maxResults int) []string {
+	return listKeysByPrefix(gUserAddressByName, prefix, maxResults)
+}
+
+// Get a list of user names starting from the given prefix. Limit the
+// number of results to maxResults.
+// The response is a JSON string.
+func ListJsonUsersByPrefix(prefix string, maxResults int) string {
+	names := ListUsersByPrefix(prefix, maxResults)
+
+	json := "["
+	for i, name := range names {
+		if i > 0 {
+			json += ", "
+		}
+		json += strconv.Quote(name)
+	}
+	json += "]"
+	return json
+}

--- a/realm/render.gno
+++ b/realm/render.gno
@@ -1,8 +1,6 @@
 package social
 
 import (
-	"sort"
-	"std"
 	"strconv"
 	"strings"
 
@@ -13,18 +11,11 @@ func Render(path string) string {
 	if path == "" {
 		str := "Welcome to GnoSocial!\n\n"
 
-		// List the users who have posted, sorted by name.
-		names := []string{}
-		gUserPostsByAddress.Iterate("", "", func(key string, value interface{}) bool {
-			if user := users.GetUserByAddress(std.Address(key)); user != nil {
-				names = append(names, user.Name)
-			}
+		// List the users who have posted. gUserAddressByName is already sorted by name.
+		gUserAddressByName.Iterate("", "", func(name string, value interface{}) bool {
+			str += " * [@" + name + "](/r/berty/social:" + name + ")" + "\n"
 			return false
 		})
-		sort.Strings(names)
-		for _, name := range names {
-			str += " * [@" + name + "](/r/berty/social:" + name + ")" + "\n"
-		}
 
 		return str
 	}

--- a/realm/social.gno
+++ b/realm/social.gno
@@ -6,5 +6,6 @@ import (
 
 var (
 	gUserPostsByAddress avl.Tree // user's std.Address -> *UserPosts
+	gUserAddressByName  avl.Tree // user's username -> std.Address
 	postsCtr            uint64   // increments Post.id globally
 )

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -11,7 +11,7 @@ import (
 //----------------------------------------
 // private utility methods
 
-// Get the userPosts for the user.
+// Get the UserPosts for the user.
 func getUserPosts(userAddr std.Address) *UserPosts {
 	userPosts, exists := gUserPostsByAddress.Get(userAddr.String())
 	if !exists {
@@ -19,6 +19,30 @@ func getUserPosts(userAddr std.Address) *UserPosts {
 	}
 
 	return userPosts.(*UserPosts)
+}
+
+// Get the UserPosts for the userAddr. If not found, add a new UserPosts to
+// gUserPostsByAddress and update gUserAddressByName with the username.
+// (The caller usually has already called usernameOf to get the username, but if
+// it is "" then this will get it.)
+func getOrCreateUserPosts(userAddr std.Address, username string) *UserPosts {
+	userPosts := getUserPosts(userAddr)
+	if userPosts != nil {
+		return userPosts
+	}
+
+	if username == "" {
+		username := usernameOf(userAddr)
+		if username == "" {
+			panic("no username for address " + userAddr.String())
+		}
+	}
+
+	userPosts = newUserPosts("/r/berty/social:"+username, userAddr)
+	gUserPostsByAddress.Set(userAddr.String(), userPosts)
+	gUserAddressByName.Set(username, userAddr)
+
+	return userPosts
 }
 
 func padZero(u64 uint64, length int) string {


### PR DESCRIPTION
The GnoSocial demo app needs to search by username. This PR has two commits:
1. Add persistent variable `gUserAddressByName`. Add a centralized utility function `getOrCreateUserPosts` which creates a new UserPosts if needed and adds it to `gUserPostsByAddress` as well as updating `gUserAddressByName`. Change public functions like `PostMessage` to use `getOrCreateUserPosts`. Also, we can simplify `Render` for the main page by listing all usernames directly from `gUserAddressByName`.
2. Add public function `ListUsersByPrefix`. (This uses a temporary local copy of `ListKeysByPrefix` which can be removed when [the PR](https://github.com/gnolang/gno/pull/1708) is merged to add this to p/demo/avlhelpers.) Also, add `ListJsonUsersByPrefix` which returns the same result a JSON array.