### PR TITLE
chore: Add GetJsonUserByName

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -214,9 +214,7 @@ func GetJsonUserByAddress(addr std.Address) string {
 		return ""
 	}
 
-	return ufmt.Sprintf(
-		"{\"address\": \"%s\", \"name\": \"%s\", \"profile\": %s, \"number\": %d, \"invites\": %d, \"inviter\": \"%s\"}",
-		user.Address.String(), user.Name, strconv.Quote(user.Profile), user.Number, user.Invites, user.Inviter.String())
+	return marshalJsonUser(user)
 }
 
 // TODO: This is a temporary copy. Remove this when they merge https://github.com/gnolang/gno/pull/1708.

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -217,6 +217,17 @@ func GetJsonUserByAddress(addr std.Address) string {
 	return marshalJsonUser(user)
 }
 
+// Call users.GetUserByName and return the result as JSON, or "" if not found.
+// (This is a temporary utility until gno.land supports returning structured data directly.)
+func GetJsonUserByName(name string) string {
+	user := users.GetUserByName(name)
+	if user == nil {
+		return ""
+	}
+
+	return marshalJsonUser(user)
+}
+
 // TODO: This is a temporary copy. Remove this when they merge https://github.com/gnolang/gno/pull/1708.
 func listKeysByPrefix(tree avl.Tree, prefix string, maxResults int) []string {
 	end := ""

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	"gno.land/p/demo/ufmt"
+	p_users "gno.land/p/demo/users"
 	"gno.land/r/demo/users"
 )
 
@@ -99,4 +101,12 @@ func usernameOf(addr std.Address) string {
 	} else {
 		return user.Name
 	}
+}
+
+// Return the User info as a JSON string.
+// (This is a temporary utility until gno.land supports returning structured data directly.)
+func marshalJsonUser(user *p_users.User) string {
+	return ufmt.Sprintf(
+		"{\"address\": \"%s\", \"name\": \"%s\", \"profile\": %s, \"number\": %d, \"invites\": %d, \"inviter\": \"%s\"}",
+		user.Address.String(), user.Name, strconv.Quote(user.Profile), user.Number, user.Invites, user.Inviter.String())
 }


### PR DESCRIPTION
This is a follow-up to PR #34 which added `GetJsonUserByAddress`.

GnoSocial needs the information from `users.GetUserByName`, but calling this remotely returns the usual result that's difficult to process. This PR adds the utility function `GetJsonUserByName` to return the `User` object as JSON. We can remove this when Gno.land is updated to return usable objects  for remote function calls.

This PR has two commits:
1. Refactor the existing `GetJsonUserByAddress` to add the utility function `marshalJsonUser`.
2. Add `GetJsonUserByName` which also uses `marshalJsonUser`.

Tested in the GnoSoclal demo app with the following code:
```
const result = await gno.qEval("gno.land/r/berty/social", `GetJsonUserByName("test_1")`);
if (!(result.startsWith('(') && result.endsWith(' string)'))) throw new Error("Malformed GetJsonUserByName response");
const quoted = result.substring(1, result.length - ' string)'.length);
const json = JSON.parse(quoted);
const user = JSON.parse(json);
```

 Example value of `json`:
```
{"address": "g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", "name": "test_1", "profile": "my profile", "number": 1, "invites": 0, "inviter": ""}
```