### PR TITLE
fix: From code review, fix newUserPosts, GetReply and RepostThread

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -91,9 +91,9 @@ func (post *Post) AddRepostTo(creator std.Address, comment string, dst *UserPost
 	return repost
 }
 
-func (thread *Post) GetReply(pid PostID) *Post {
+func (post *Post) GetReply(pid PostID) *Post {
 	pidkey := postIDKey(pid)
-	replyI, ok := thread.repliesAll.Get(pidkey)
+	replyI, ok := post.repliesAll.Get(pidkey)
 	if !ok {
 		return nil
 	} else {

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -67,15 +67,16 @@ func PostReply(userPostsAddr std.Address, threadid, postid PostID, body string) 
 func RepostThread(userPostsAddr std.Address, threadid PostID, comment string) PostID {
 	std.AssertOriginCall()
 	caller := std.GetOrigCaller()
+	if userPostsAddr == caller {
+		panic("Cannot repost a user's own message")
+	}
+
 	name := usernameOf(caller)
 	if name == "" {
 		panic("please register")
 	}
 	dstUserPosts := getOrCreateUserPosts(caller, name)
 
-	if userPostsAddr == caller {
-		panic("Cannot repost a user's own message")
-	}
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -33,9 +33,11 @@ func newUserPosts(url string, userAddr std.Address) *UserPosts {
 		panic("userPosts already exists")
 	}
 	return &UserPosts{
-		url:      url,
-		userAddr: userAddr,
-		threads:  avl.Tree{},
+		url:       url,
+		userAddr:  userAddr,
+		threads:   avl.Tree{},
+		followers: avl.Tree{},
+		following: avl.Tree{},
 	}
 }
 


### PR DESCRIPTION
From a code review by @D4ryl00, this PR fixes:
1. In `newUserPosts`, initialize fields followers and following.
2. In `GetReply`, rename the Post object from `thread` to `post` (to be consistent with the other methods).
3. In 'RepostThread`, move the check for `userPostsAddr == caller` earlier. (Fail as early as possible to save CPU.)