### PR TITLE
chore: Rename chain ID tendermint_test to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install the faucet, in another terminal enter:
 
 To start the faucet using the mnemonic of the test1 key, enter:
 
-    ./build/faucet serve -send-amount 10000000000ugnot -chain-id tendermint_test -remote http://localhost:36657 -mnemonic "source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast"
+    ./build/faucet serve -send-amount 10000000000ugnot -chain-id dev -remote http://localhost:36657 -mnemonic "source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast"
 
 To send coins to your user account, in another terminal enter the following (with your account number):
 
@@ -31,11 +31,11 @@ To send coins to your user account, in another terminal enter the following (wit
 
 To register the user, enter the following (change jefft0 to your account username):
 
-    gnokey maketx call -pkgpath "gno.land/r/demo/users" -func "Register" -args "" -args "jefft0" -args "Profile description" -gas-fee "10000000ugnot" -gas-wanted "2000000" -send "200000000ugnot" -broadcast -chainid tendermint_test -remote 127.0.0.1:36657 jefft0
+    gnokey maketx call -pkgpath "gno.land/r/demo/users" -func "Register" -args "" -args "jefft0" -args "Profile description" -gas-fee "10000000ugnot" -gas-wanted "2000000" -send "200000000ugnot" -broadcast -chainid dev -remote 127.0.0.1:36657 jefft0
 
 To post a message, enter the following (change jefft0 to your account username):
 
-    gnokey maketx call -pkgpath "gno.land/r/berty/social" -func "PostMessage" -args "My first post" -gas-fee "1000000ugnot" -gas-wanted "5000000" -broadcast -chainid tendermint_test -remote 127.0.0.1:36657 jefft0
+    gnokey maketx call -pkgpath "gno.land/r/berty/social" -func "PostMessage" -args "My first post" -gas-fee "1000000ugnot" -gas-wanted "5000000" -broadcast -chainid dev -remote 127.0.0.1:36657 jefft0
 
 Note that this returns the "thread ID" of the new post like "(1 gno.land/r/berty/social.PostID)".
 
@@ -46,4 +46,4 @@ To view the result in a browser, go to the following URL (change jefft0 to your 
 To post a reply, enter the following where THREADID and POSTID are both the thread ID from PostMessage
 (change the account number and jefft0 to your account):
 
-    gnokey maketx call -pkgpath "gno.land/r/berty/social" -func "PostReply" -args "g1juz2yxmdsa6audkp6ep9vfv80c8p5u76e03vvh" -args THREADID -args POSTID -args "my reply" -gas-fee "1000000ugnot" -gas-wanted "5000000" -broadcast -chainid tendermint_test -remote 127.0.0.1:36657 jefft0
+    gnokey maketx call -pkgpath "gno.land/r/berty/social" -func "PostReply" -args "g1juz2yxmdsa6audkp6ep9vfv80c8p5u76e03vvh" -args THREADID -args POSTID -args "my reply" -gas-fee "1000000ugnot" -gas-wanted "5000000" -broadcast -chainid dev -remote 127.0.0.1:36657 jefft0

--- a/mobile/src/hooks/use-gno.ts
+++ b/mobile/src/hooks/use-gno.ts
@@ -95,7 +95,7 @@ export const useGno = (): GnoResponse => {
 
     // Set the initial configuration where it's different from the default.
     await clientInstance.setRemote(new SetRemoteRequest({ remote: 'testnet.gno.berty.io:36657' }));
-    await clientInstance.setChainID(new SetChainIDRequest({ chainId: 'tendermint_test' }));
+    await clientInstance.setChainID(new SetChainIDRequest({ chainId: 'dev' }));
 
     return clientInstance;
   };


### PR DESCRIPTION
A [recent commit](https://github.com/gnolang/gno/blame/01e91be7bbde8e9cfc2069f66f24bc83d677103a/contribs/gnodev/main.go#L54) updates gnodev to use the chain ID "dev". When gnodev is updated locally or on the Berty test node, it needs to use this chain ID. So, this PR renames "tendermint_test" to "dev".