### PR TITLE
Chore: Save the state of home posts and add RefreshHomePosts

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -30,11 +30,11 @@ type Post struct {
 	id         PostID
 	creator    std.Address
 	body       string
-	replies    avl.Tree    // Post.id -> *Post
-	repliesAll avl.Tree    // Post.id -> *Post (all replies, for top-level posts)
-	reposts    avl.Tree    // UserPosts user std.Address -> Post.id
-	threadID   PostID      // original Post.id
-	parentID   PostID      // parent Post.id (if reply or repost)
+	replies    avl.Tree    // PostID -> *Post
+	repliesAll avl.Tree    // PostID -> *Post (all replies, for top-level posts)
+	reposts    avl.Tree    // UserPosts user std.Address -> PostID
+	threadID   PostID      // original PostID
+	parentID   PostID      // parent PostID (if reply or repost)
 	repostUser std.Address // UserPosts user std.Address of original post (if repost)
 	createdAt  time.Time
 }

--- a/realm/post.gno
+++ b/realm/post.gno
@@ -87,6 +87,8 @@ func (post *Post) AddRepostTo(creator std.Address, comment string, dst *UserPost
 	pidkey := postIDKey(pid)
 	repost := newPost(dst, pid, creator, comment, pid, post.id, post.userPosts.userAddr)
 	dst.threads.Set(pidkey, repost)
+	// Also add to the home posts.
+	dst.homePosts.Set(pidkey, repost)
 	post.reposts.Set(creator.String(), pid)
 	return repost
 }

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -3,7 +3,6 @@ package social
 import (
 	"std"
 	"strconv"
-	"time"
 
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ufmt"
@@ -125,8 +124,23 @@ func GetThreadPosts(userPostsAddr std.Address, threadID int, replyID int, startI
 	}
 }
 
+// Update the home posts by scanning all posts from all followed users and adding the
+// followed posts since the last call to RefreshHomePosts (or since started following the user).
+// Return the new count of home posts. The result is something like "(12 int)".
+func RefreshHomePosts(userPostsAddr std.Address) int {
+	userPosts := getUserPosts(userPostsAddr)
+	if userPosts == nil {
+		panic("posts for userPostsAddr do not exist")
+	}
+	userPosts.refreshHomePosts()
+
+	return userPosts.homePosts.Size()
+}
+
 // Get the number of posts which GetHomePosts or GetJsonHomePosts will return.
 // The result is something like "(12 int)".
+// This returns the current count of the home posts (without need to pay gas). To include the
+// latest followed posts, call RefreshHomePosts.
 func GetHomePostsCount(userPostsAddr std.Address) int {
 	return GetHomePosts(userPostsAddr).Size()
 }
@@ -136,22 +150,14 @@ func GetHomePostsCount(userPostsAddr std.Address) int {
 // The response is a map of postID -> *Post. The avl.Tree sorts by the post ID which is
 // unique for every post and increases in time.
 // If you just want the total count, use GetHomePostsCount.
+// This returns the current state of the home posts (without need to pay gas). To include the
+// latest followed posts, call RefreshHomePosts.
 func GetHomePosts(userPostsAddr std.Address) *avl.Tree {
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")
 	}
-
-	// TODO: This computes all home posts on each call. Can this be more efficient?
-	allPosts := avl.Tree{} // postID -> *Post
-	userPosts.threads.Iterate("", "", func(id string, postI interface{}) bool {
-		post := postI.(*Post)
-		allPosts.Set(id, post)
-		return false
-	})
-	userPosts.addFollowedPosts(&allPosts, time.Time{}, debugNow())
-
-	return &allPosts
+	return &userPosts.homePosts
 }
 
 // Get home posts for a user (using GetHomePosts), which are the user's top-level posts plus all
@@ -159,6 +165,8 @@ func GetHomePosts(userPostsAddr std.Address) *avl.Tree {
 // Limit the response to posts from startIndex up to (not including) endIndex within the home posts.
 // If you just want the total count, use GetHomePostsCount.
 // The response is a JSON string.
+// This returns the current state of the home posts (without need to pay gas). To include the
+// latest posts, call RefreshHomePosts.
 func GetJsonHomePosts(userPostsAddr std.Address, startIndex int, endIndex int) string {
 	allPosts := GetHomePosts(userPostsAddr)
 	postsJson := ""

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -24,7 +24,7 @@ type FollowingInfo struct {
 type UserPosts struct {
 	url       string
 	userAddr  std.Address
-	threads   avl.Tree // Post.id -> *Post
+	threads   avl.Tree // PostID -> *Post
 	followers avl.Tree // std.Address -> ""
 	following avl.Tree // std.Address -> *FollowingInfo
 }

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -15,6 +15,7 @@ import (
 
 type FollowingInfo struct {
 	startedFollowingAt time.Time
+	startedPostsCtr    PostID
 }
 
 // UserPosts is similar to boards.Board where each user has their own "board" for
@@ -22,11 +23,13 @@ type FollowingInfo struct {
 // A user's "home feed" may contain other posts (from followed users, etc.) but this only
 // has the top-level posts from the user (not replies to other user's posts).
 type UserPosts struct {
-	url       string
-	userAddr  std.Address
-	threads   avl.Tree // PostID -> *Post
-	followers avl.Tree // std.Address -> ""
-	following avl.Tree // std.Address -> *FollowingInfo
+	url           string
+	userAddr      std.Address
+	threads       avl.Tree // PostID -> *Post
+	homePosts     avl.Tree // PostID -> *Post. Includes this user's threads posts plus posts of users being followed.
+	lastRefreshId PostID   // Updated by refreshHomePosts
+	followers     avl.Tree // std.Address -> ""
+	following     avl.Tree // std.Address -> *FollowingInfo
 }
 
 // Create a new userPosts for the user. Panic if there is already a userPosts for the user.
@@ -35,11 +38,13 @@ func newUserPosts(url string, userAddr std.Address) *UserPosts {
 		panic("userPosts already exists")
 	}
 	return &UserPosts{
-		url:       url,
-		userAddr:  userAddr,
-		threads:   avl.Tree{},
-		followers: avl.Tree{},
-		following: avl.Tree{},
+		url:           url,
+		userAddr:      userAddr,
+		threads:       avl.Tree{},
+		homePosts:     avl.Tree{},
+		lastRefreshId: PostID(postsCtr), // Ignore past messages of followed users.
+		followers:     avl.Tree{},
+		following:     avl.Tree{},
 	}
 }
 
@@ -58,6 +63,8 @@ func (userPosts *UserPosts) AddThread(body string) *Post {
 	pidkey := postIDKey(pid)
 	thread := newPost(userPosts, pid, userPosts.userAddr, body, pid, 0, "")
 	userPosts.threads.Set(pidkey, thread)
+	// Also add to the home posts.
+	userPosts.homePosts.Set(pidkey, thread)
 	return thread
 }
 
@@ -70,6 +77,7 @@ func (userPosts *UserPosts) Follow(followedAddr std.Address) {
 	if followedUserPosts != nil {
 		userPosts.following.Set(followedAddr.String(), &FollowingInfo{
 			startedFollowingAt: debugNow(),
+			startedPostsCtr:    PostID(postsCtr), // Ignore past messages.
 		})
 		followedUserPosts.followers.Set(userPosts.userAddr.String(), "")
 	}
@@ -101,19 +109,19 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	}
 	str += followers + " &nbsp;" + following + "\n\n"
 
-	str += "\\[[post](" + userPosts.GetPostFormURL() + ")] \\[[follow](" + userPosts.GetFollowFormURL() + ")]\n\n"
-
-	allPosts := avl.Tree{} // postTime -> *Post
-	userPosts.threads.Iterate("", "", func(id string, postI interface{}) bool {
-		post := postI.(*Post)
-		allPosts.Set(id, post)
-		return false
-	})
+	str += "\\[[post](" + userPosts.GetPostFormURL() + ")] \\[[follow](" + userPosts.GetFollowFormURL() + ")]"
 	if includeFollowed {
-		userPosts.addFollowedPosts(&allPosts, time.Time{}, debugNow())
+		str += " \\[[refresh](" + userPosts.GetRefreshFormURL() + ")]"
 	}
+	str += "\n\n"
 
-	allPosts.Iterate("", "", func(key string, postI interface{}) bool {
+	var posts *avl.Tree
+	if includeFollowed {
+		posts = &userPosts.homePosts
+	} else {
+		posts = &userPosts.threads
+	}
+	posts.Iterate("", "", func(key string, postI interface{}) bool {
 		str += "----------------------------------------\n"
 		str += postI.(*Post).RenderSummary() + "\n"
 		return false
@@ -204,11 +212,17 @@ func (userPosts *UserPosts) GetUnfollowFormURL(followedAddr std.Address) string 
 		"&followedAddr=" + followedAddr.String()
 }
 
-// Scan userPosts.following and for all posts from all followed users from startTime up to (not including) endTime.
-// if startTime.IsZero(), then use the FollowingInfo startedFollowingAt time.
-// Add the posts to the followedPosts map of postID -> *Post. The avl.Tree sorts by the post ID which is
-// unique for every post and increases in time.
-func (userPosts *UserPosts) addFollowedPosts(followedPosts *avl.Tree, startTime time.Time, endTime time.Time) {
+func (userPosts *UserPosts) GetRefreshFormURL() string {
+	return "/r/berty/social?help&__func=RefreshHomePosts" +
+		"&userPostsAddr=" + userPosts.userAddr.String()
+}
+
+// Scan userPosts.following for all posts from all followed users starting from lastRefreshId+1 .
+// Add the posts to the homePosts avl.Tree, which is sorted by the post ID which is unique for every post and
+// increases in time. When finished, update lastRefreshId.
+func (userPosts *UserPosts) refreshHomePosts() {
+	minStartKey := postIDKey(userPosts.lastRefreshId + 1)
+
 	userPosts.following.Iterate("", "", func(followedAddr string, infoI interface{}) bool {
 		followedUserPosts := getUserPosts(std.Address(followedAddr))
 		if followedUserPosts == nil {
@@ -216,27 +230,21 @@ func (userPosts *UserPosts) addFollowedPosts(followedPosts *avl.Tree, startTime 
 		}
 
 		info := infoI.(*FollowingInfo)
-		if startTime.IsZero() {
-			startTime = info.startedFollowingAt
+		startKey := minStartKey
+		if info.startedPostsCtr > userPosts.lastRefreshId {
+			// Started following after the last refresh. Ignore messages before started following.
+			startKey := postIDKey(info.startedPostsCtr + 1)
 		}
 
-		// TODO: This scans all threads. Is it possible to begin at startTime?
-		followedUserPosts.threads.Iterate("", "", func(id string, postI interface{}) bool {
-			post := postI.(*Post)
-			if post.createdAt.Before(startTime) {
-				// Keep scanning.
-				return false
-			} else if !post.createdAt.Before(endTime) {
-				// Finished.
-				return true
-			}
-
-			followedPosts.Set(id, post)
+		followedUserPosts.threads.Iterate(startKey, "", func(id string, postI interface{}) bool {
+			userPosts.homePosts.Set(id, postI.(*Post))
 			return false
 		})
 
 		return false
 	})
+
+	userPosts.lastRefreshId = PostID(postsCtr)
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
Currently, `GetHomePosts` computes the home posts (including all followed posts) each time it is called. This is necessary because we want to call it with QEval (no gas fee) which can't update the realm data to save the result. But this is not scalable.  This PR solves the problem by saving the state of the home posts. This is returned by `GetHomePosts`, but we add a separate `RefreshHomePosts` which is requires gas and adds the followed posts since the last call.

* In a first minor commit, fix comments because the type `Post.id` should be `PostID`
* In `UserPosts`, add the avl.Tree `homePosts` which saves the state of the home posts. In `GetHomePosts`, simply return this avl.Tree.
* Update `RenderUserPosts` to use the current state of `homePosts` (if viewing the home feed). Also add a helper link to for "refresh".
* In `AddThread` and `AddRepostTo`, add the new post to `homePosts` at the same time that we add to `threads`. This way, the home posts at least have the user's own posts without needing to call `RefreshHomePosts`.
* Rename `addFollowedPosts` to `refreshHomePosts`. In `UserPosts`, add `lastRefreshId` and use it to only refresh followed posts since the last call to `refreshHomePosts`.
* In `FollowingInfo`, add `startedPostsCtr`. Use this in `refreshHomePosts` to only add followed posts after started following.
* Add the public function `RefreshHomePosts ` which returns the new size of the home posts. An app can call this, and if the number of posts has increased then the app should refresh the display of the home feed.