### PR TITLE
chore: In UserPosts.Follow, do nothing if already following

### DIFF
--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -68,11 +68,17 @@ func (userPosts *UserPosts) AddThread(body string) *Post {
 	return thread
 }
 
+// If already following followedAddr, then do nothing.
 // If there is a UserPosts for followedAddr, then add it to following,
 // and add this user to its followers.
 // If there is no UserPosts for followedAddr, then do nothing. (We don't expect
 // this because this is usually called by clicking on the display page of followedAddr.)
 func (userPosts *UserPosts) Follow(followedAddr std.Address) {
+	if userPosts.following.Has(followedAddr.String()) {
+		// Already following.
+		return
+	}
+
 	followedUserPosts := getUserPosts(followedAddr)
 	if followedUserPosts != nil {
 		userPosts.following.Set(followedAddr.String(), &FollowingInfo{


### PR DESCRIPTION
UserPosts `Follow` [updates the `following` avl.Tree](https://github.com/gnolang/gnosocial/blob/bf135e41a0f5328ea29d8024a46327d2419822dc/realm/userposts.gno#L78-L81) with a `FollowingInfo` structure which includes the followed user's latest post ID. This is so that the home posts only include posts of another user after starting to follow them. Normally, `Follow` is only called once to follow another user. The problem is that if it is called a second time, then it will update with a new `FollowingInfo` which replaces the previous one. This could result in to showing some followed posts which were made after the initial call to `Follow`.

This PR solves this problem by checking if the other user is already being followed. If yes, then do nothing.