### PR TITLE
chore: mobile/README: Add macOS 14. Remove macOS 12

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -8,7 +8,7 @@ The GnoSocial mobile app uses Expo. You can review the general expo requirements
 
 Here are specific steps to install the requirements on your platform.
 
-### Install requirements for macOS 12 and macOS 13
+### Install requirements for macOS 13 and macOS 14
 
 (If you are on Ubuntu, see the next section to install requirements.)
 


### PR DESCRIPTION
Tested the instructions for `make ios` in mobile/README on a macOS 14 virtual machine, so add this in the README. Remove unsupported macOS 12.