### PR TITLE
chore: In GetJsonFollowers and GetJsonFollowing, add start and end index

### DIFF
--- a/realm/public.gno
+++ b/realm/public.gno
@@ -266,22 +266,24 @@ func GetJsonUserPostsInfo(address std.Address) string {
 
 // Get the UserPosts for the user with the given address, and return
 // the list of followers. If the user address is not found, return "".
+// Limit the response to entries from startIndex up to (not including) endIndex.
 // The response is a JSON string.
-func GetJsonFollowers(address std.Address) string {
+func GetJsonFollowers(address std.Address, startIndex int, endIndex int) string {
 	userPosts := getUserPosts(address)
 	if userPosts == nil {
 		return ""
 	}
 
-	json := "[\n  "
-	userPosts.followers.Iterate("", "", func(addr string, value interface{}) bool {
-		if len(json) > 4 {
+	json := ufmt.Sprintf("{\"n_followers\": %d, \"followers\": [\n  ", userPosts.followers.Size())
+	for i := startIndex; i < endIndex && i < userPosts.followers.Size(); i++ {
+		addr, _ := userPosts.followers.GetByIndex(i)
+
+		if i > startIndex {
 			json += ",\n  "
 		}
 		json += ufmt.Sprintf(`{"address": "%s"}`, addr)
-		return false
-	})
-	json += "]"
+	}
+	json += "]}"
 
 	return json
 }
@@ -289,16 +291,19 @@ func GetJsonFollowers(address std.Address) string {
 // Get the UserPosts for the user with the given address, and return
 // the list of other users that this user is following.
 // If the user address is not found, return "".
+// Limit the response to entries from startIndex up to (not including) endIndex.
 // The response is a JSON string.
-func GetJsonFollowing(address std.Address) string {
+func GetJsonFollowing(address std.Address, startIndex int, endIndex int) string {
 	userPosts := getUserPosts(address)
 	if userPosts == nil {
 		return ""
 	}
 
-	json := "[\n  "
-	userPosts.following.Iterate("", "", func(addr string, infoI interface{}) bool {
-		if len(json) > 4 {
+	json := ufmt.Sprintf("{\"n_following\": %d, \"following\": [\n  ", userPosts.following.Size())
+	for i := startIndex; i < endIndex && i < userPosts.following.Size(); i++ {
+		addr, infoI := userPosts.following.GetByIndex(i)
+
+		if i > startIndex {
 			json += ",\n  "
 		}
 		startedAt, err := infoI.(*FollowingInfo).startedFollowingAt.MarshalJSON()
@@ -307,9 +312,8 @@ func GetJsonFollowing(address std.Address) string {
 		}
 		json += ufmt.Sprintf(`{"address": "%s", "started_following_at": %s}`,
 			addr, string(startedAt))
-		return false
-	})
-	json += "]"
+	}
+	json += "]}"
 
 	return json
 }


### PR DESCRIPTION
If the avl.Tree for followers and following has more than about 1000 entries, then it takes too much gas to iterate it. So, similar to `GetJsonHomePosts`, in `GetJsonFollowers` and `GetJsonFollowing` we add a start and end index.

BREAKING CHANGES:
* In `GetJsonFollowers` and `GetJsonFollowing`, add params `startIndex` and `endIndex`.
* In the returned JSON string of `GetJsonFollowers`, add `n_followers`. (See example below.)
* In the returned JSON string of `GetJsonFollowing`, add `n_following`. (See example below.)

Tested `GetJsonFollowers` in the GnoSoclal demo app with the following code:
```
const result = await gno.qEval("gno.land/r/berty/social", `GetJsonFollowers("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", 0, 100)`);
if (!(result.startsWith('(') && result.endsWith(' string)'))) throw new Error("Malformed GetJsonFollowers response");
const quoted = result.substring(1, result.length - ' string)'.length);
const json = JSON.parse(quoted);
const followers = JSON.parse(json);
```

 Example value of `json`:
```
{"n_followers": 2, "followers": [
  {"address": "g1juz2yxmdsa6audkp6ep9vfv80c8p5u76e03vvh"},
  {"address": "g1qrhd7x2j7n8p036nd3jh5d8rcwufyxcssvzssz"}]}
```

Tested `GetJsonFollowing` in the GnoSoclal demo app with the following code:
```
const result = await gno.qEval("gno.land/r/berty/social", `GetJsonFollowing("g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5", 0, 100)`);
if (!(result.startsWith('(') && result.endsWith(' string)'))) throw new Error("Malformed GetJsonFollowing response");
const quoted = result.substring(1, result.length - ' string)'.length);
const json = JSON.parse(quoted);
const following = JSON.parse(json);
```

 Example value of `json`:
```
{"n_following": 2, "following": [
  {"address": "g1juz2yxmdsa6audkp6ep9vfv80c8p5u76e03vvh", "started_following_at": "2024-04-10T10:01:19Z"},
  {"address": "g1qrhd7x2j7n8p036nd3jh5d8rcwufyxcssvzssz", "started_following_at": "2024-04-10T07:50:40Z"}]}
```
