### PR TITLE
chore: Add .gitattributes for gno syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gno linguist-language=Go


### PR DESCRIPTION
Add the [same .gitattributes](https://github.com/gnolang/gno/blob/d44c9a5dcd28c5800c9529f47be168f38ebb0ffa/.gitattributes#L1) for gno syntax highlighting as in gno.
