### PR TITLE
fix: remove account button

### DIFF
--- a/mobile/app/[account]/_layout.tsx
+++ b/mobile/app/[account]/_layout.tsx
@@ -22,6 +22,12 @@ export default function DynamicLayout() {
           presentation: "modal",
         }}
       />
+			<Stack.Screen
+				name="remove"
+				options={{
+					presentation: "modal",
+				}}
+			/>
     </Stack>
   );
 }

--- a/mobile/app/[account]/remove.tsx
+++ b/mobile/app/[account]/remove.tsx
@@ -1,0 +1,19 @@
+import { selectFollowers } from "redux/features/profileSlice";
+import { logedOut, useAppDispatch, useAppSelector } from "@gno/redux";
+import { User } from "@gno/types";
+import RemoveAccountContent from "@gno/components/view/account/remove-account.tsx";
+import { useGno } from "@gno/hooks/use-gno";
+
+export default function Page() {
+  const gno = useGno();
+  const dispatch = useAppDispatch();
+  const data = useAppSelector(selectFollowers);
+
+  const onConfirm = async (item: User) => {
+    await gno.deleteAccount(item.address, undefined, true);
+
+    dispatch(logedOut());
+  };
+
+  return <RemoveAccountContent data={data} onConfirm={onConfirm} />;
+}

--- a/mobile/app/home/profile.tsx
+++ b/mobile/app/home/profile.tsx
@@ -67,8 +67,8 @@ export default function Page() {
     }
   };
 
-  const onDeleteAccount = async () => {
-    router.push("settings/remove-account");
+  const onRemoveAccount = async () => {
+		router.navigate({ pathname: "account/remove" });
   };
 
   const onPressLogout = async () => {
@@ -91,8 +91,8 @@ export default function Page() {
             <Button.TouchableOpacity title="Onboard the current user" onPress={onboard} variant="primary" />
             <Button.TouchableOpacity title="Logout" onPress={onPressLogout} style={styles.logout} variant="primary-red" />
             <Button.TouchableOpacity
-              title="Delete Account"
-              onPress={onDeleteAccount}
+              title="Remove Account"
+              onPress={onRemoveAccount}
               style={styles.logout}
               variant="primary-red"
             />

--- a/mobile/components/view/account/remove-account.tsx/index.tsx
+++ b/mobile/components/view/account/remove-account.tsx/index.tsx
@@ -1,0 +1,35 @@
+import Layout from "@gno/components/layout";
+import ModalHeader from "@gno/components/layout/modal-header";
+import Text from "@gno/components/text";
+import { Following, User } from "@gno/types";
+import { selectAccount, useAppSelector } from "@gno/redux";
+import Button from "@gno/components/button";
+import Spacer from "@gno/components/spacer";
+
+interface Props {
+  data: Following[];
+  onConfirm: (account: User) => void;
+}
+
+function RemoveAccountContent({ data, onConfirm }: Props) {
+  const account = useAppSelector(selectAccount);
+
+  if (!account) {
+    return null;
+  }
+
+  return (
+    <Layout.Container>
+      <ModalHeader>
+        <Text.Title>Remove Account</Text.Title>
+      </ModalHeader>
+      <Layout.Body>
+        <Text.Body>Do you want to remove the account {account.name} from your list?</Text.Body>
+        <Spacer space={32} />
+        <Button.TouchableOpacity title={`Remove ${account.name}`} onPress={() => onConfirm(account)} variant="primary-red" />
+      </Layout.Body>
+    </Layout.Container>
+  );
+}
+
+export default RemoveAccountContent;


### PR DESCRIPTION
This PR fixes the remove account button by implementing a new router and calling the gnokey deleteAccount function.