### PR TITLE
feat: rendering url and email

### DIFF
--- a/mobile/components/feed/post-content-label.tsx
+++ b/mobile/components/feed/post-content-label.tsx
@@ -13,8 +13,8 @@ const PostContentLabel: React.FC<Props> = ({ children, onMentionPress }) => {
   return (
     <Autolink
       text={children}
-      email={false}
-      url={false}
+      email={true}
+      url={true}
       matchers={[
         {
           pattern: PATTERN,


### PR DESCRIPTION
We are enabling URL and email rendering as links.

<img src="https://github.com/user-attachments/assets/868f08d3-5724-401b-aa15-68fafbc60705"
width="200" />