### PR TITLE
chore: Revert PR 25: Remove the debugNow hack

### DIFF
--- a/realm/post.gno
+++ b/realm/post.gno
@@ -11,8 +11,6 @@ import (
 	"gno.land/p/moul/txlink"
 )
 
-var debugNowOffset time.Duration
-
 //----------------------------------------
 // Post
 
@@ -62,7 +60,7 @@ func newPost(userPosts *UserPosts, id PostID, creator std.Address, body string, 
 		parentID:   parentID,
 		repostUser: repostUser,
 		reactions:  avl.NewTree(),
-		createdAt:  debugNow(),
+		createdAt:  time.Now(),
 	}
 }
 
@@ -321,15 +319,4 @@ func getPosts(posts avl.Tree, startIndex int, endIndex int) string {
 
 	json += "]}"
 	return json
-}
-
-// Until the problem explained in https://github.com/gnolang/gno/issues/1509
-// is solved, we need post timestamps to be different on reload. This
-// calls Time.Now() and adds an offset which increases by one minute on each call.
-// Therefore, in "normal" operation (before reload) the times are close to the
-// expected value. After reload, all times will be the time of reload, increasing by
-// one minute each, which is not ideal but at least they are different and in order.
-func debugNow() time.Time {
-	debugNowOffset += time.Minute
-	return time.Now().Add(debugNowOffset)
 }

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -84,7 +84,7 @@ func (userPosts *UserPosts) Follow(followedAddr std.Address) PostID {
 	followedUserPosts := getUserPosts(followedAddr)
 	if followedUserPosts != nil {
 		userPosts.following.Set(followedAddr.String(), &FollowingInfo{
-			startedFollowingAt: debugNow(),
+			startedFollowingAt: time.Now(),
 			startedPostsCtr:    PostID(postsCtr), // Ignore past messages.
 		})
 		followedUserPosts.followers.Set(userPosts.userAddr.String(), "")


### PR DESCRIPTION
PR https://github.com/gnoverse/dsocial/pull/25 added a "hack" function `debugNow` to solve the problem with "timestamps on reload". Now, PR https://github.com/gnolang/gno/pull/2943 has been merged to fix it. This PR reverts to remove `debugNow` and restore `time.Now` .