### PR TITLE
fix: semantic release working in a sub directory

### DIFF
--- a/mobile/.releaserc
+++ b/mobile/.releaserc
@@ -1,14 +1,7 @@
 {
   "branches": ["main"],
   "plugins": [
-      [
-          "semantic-release-expo",
-          {
-            "manifests": [
-                "./mobile/app.json",
-            ]
-          }
-      ],
+    "semantic-release-expo",
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",


### PR DESCRIPTION
Try to put the semantic release conf in the mobile sub directory to have `semantic-release-expo` plugin working without any configuration.