### PR TITLE
fix: Use gnonative 4.7.3

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,7 +13,7 @@
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",
         "@connectrpc/connect-web": "^2.0.3",
-        "@gnolang/gnonative": "^4.7.2",
+        "@gnolang/gnonative": "^4.7.3",
         "@reduxjs/toolkit": "^2.1.0",
         "base-64": "^1.0.0",
         "date-fns": "^3.6.0",
@@ -2776,9 +2776,9 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.2.tgz",
-      "integrity": "sha512-hiDMy1SoufEOCpuwzYceqDQ1Avl95XVUlcs/ZOd1IvXJ0o5fI8une4cg7+mCSyblI7DItryWdtgI/gg0dqQx9A==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-4.7.3.tgz",
+      "integrity": "sha512-xf2wlVSiLhutmmgRnUnCPFG+hpCrSP3Or/pMMOxOBjAq6e1pnwfK0YA2A/hxz/dH+88gtJLpfex/8k443OEENw==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
         "@connectrpc/connect": "^2.0.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,7 +16,7 @@
     "@bufbuild/protobuf": "^2.6.2",
     "@connectrpc/connect": "^2.0.3",
     "@connectrpc/connect-web": "^2.0.3",
-    "@gnolang/gnonative": "^4.7.2",
+    "@gnolang/gnonative": "^4.7.3",
     "@reduxjs/toolkit": "^2.1.0",
     "base-64": "^1.0.0",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
gnonative PR https://github.com/gnolang/gnonative/pull/217 is merged which fixes the DB implementation. Update to use the new gnonative npm package.