### PR TITLE
chore: update realm for latest gno compatibility

### DIFF
--- a/.github/workflows/realm-tests.yml
+++ b/.github/workflows/realm-tests.yml
@@ -1,0 +1,65 @@
+name: Realm tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  realm-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout dsocial
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Checkout gnolang/gno
+        uses: actions/checkout@v4
+        with:
+          repository: gnolang/gno
+          # Pin to the gno version this realm was developed against.
+          # Update this ref when bumping gno compatibility.
+          ref: 2efd147d9124e29a57146913d93a3e1f983e083d
+          path: .gno
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-gno-${{ hashFiles('.gno/go.sum', '.gno/contribs/gnodev/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-gno-
+
+      - name: Install gnokey
+        working-directory: .gno
+        run: go install ./gno.land/cmd/gnokey
+
+      - name: Install gnodev
+        working-directory: .gno/contribs/gnodev
+        run: go install .
+
+      - name: Start gnodev
+        run: |
+          gnodev realm/ > /tmp/gnodev.log 2>&1 &
+          echo $! > /tmp/gnodev.pid
+          # Wait up to 60s for the RPC endpoint to be ready
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:26657/status > /dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -sf http://localhost:26657/status > /dev/null 2>&1 \
+            || { echo "gnodev did not start in time"; cat /tmp/gnodev.log; exit 1; }
+
+      - name: Run realm tests
+        run: ./realm/tests/test.sh
+
+      - name: Stop gnodev
+        if: always()
+        run: kill $(cat /tmp/gnodev.pid) 2>/dev/null || true

--- a/.github/workflows/realm-tests.yml
+++ b/.github/workflows/realm-tests.yml
@@ -45,6 +45,15 @@ jobs:
         working-directory: .gno/contribs/gnodev
         run: go install .
 
+      # The test1 key has a fixed address on every gnodev instance.
+      # We deploy the realm under that address so no namespace registration
+      # is required, and gnomod.toml matches the --pkgpath exactly.
+      - name: Patch gnomod.toml for CI
+        env:
+          TEST1_ADDR: g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5
+        run: |
+          sed -i "s|module = \"gno.land/r/berty/social\"|module = \"gno.land/r/${TEST1_ADDR}/social\"|" realm/gnomod.toml
+
       - name: Start gnodev
         run: |
           gnodev realm/ > /tmp/gnodev.log 2>&1 &
@@ -58,6 +67,8 @@ jobs:
             || { echo "gnodev did not start in time"; cat /tmp/gnodev.log; exit 1; }
 
       - name: Run realm tests
+        env:
+          PKG_PATH: gno.land/r/g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5/social
         run: ./realm/tests/test.sh
 
       - name: Stop gnodev

--- a/.github/workflows/realm-tests.yml
+++ b/.github/workflows/realm-tests.yml
@@ -55,8 +55,10 @@ jobs:
           sed -i "s|module = \"gno.land/r/berty/social\"|module = \"gno.land/r/${TEST1_ADDR}/social\"|" realm/gnomod.toml
 
       - name: Start gnodev
+        env:
+          GNOROOT: ${{ github.workspace }}/.gno
         run: |
-          gnodev realm/ > /tmp/gnodev.log 2>&1 &
+          gnodev staging --no-web --no-watch realm/ > /tmp/gnodev.log 2>&1 &
           echo $! > /tmp/gnodev.pid
           # Wait up to 60s for the RPC endpoint to be ready
           for i in $(seq 1 60); do

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.5
+golang 1.24.4

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then deploy with `gnokey`:
 | `NODE_ADDR` | `http://localhost:26657`  | RPC endpoint        |
 | `PKG_PATH`  | `gno.land/r/berty/social` | Deployed realm path |
 
-Example for test12:
+Example for a remote chain:
 
     CHAIN_ID=test12 \
     NODE_ADDR=http://test12.example.org:26657 \

--- a/README.md
+++ b/README.md
@@ -44,3 +44,51 @@ To post a reply, enter the following where THREADID and POSTID are both the thre
 (change the account address and jefft000 to your account):
 
     gnokey maketx call -pkgpath "gno.land/r/berty/social" -func "PostReply" -args "g1juz2yxmdsa6audkp6ep9vfv80c8p5u76e03vvh" -args THREADID -args POSTID -args "my reply" -gas-fee "1000000ugnot" -gas-wanted "100000000" -broadcast -chainid dev -remote 127.0.0.1:26657 jefft000
+
+## Deploy the realm (addpkg)
+
+Before deploying, update `realm/gnomod.toml` so the `module` field matches the `--pkgpath` you intend to use:
+
+```toml
+module = "gno.land/r/<your-address>/social"
+gno = "0.9"
+```
+
+Then deploy with `gnokey`:
+
+    gnokey maketx addpkg \
+      --pkgpath "gno.land/r/<your-address>/social" \
+      --pkgdir ./realm \
+      --gas-fee 1000000ugnot \
+      --gas-wanted 50000000 \
+      --broadcast \
+      --chainid <chain-id> \
+      --remote <rpc-endpoint> \
+      <your-key>
+
+> **Important:** `gnomod.toml` `module` and `--pkgpath` must be identical. A mismatch causes a VM panic (`unexpected node with location`) when any transaction is executed against the realm.
+
+## Integration tests
+
+`realm/tests/test.sh` is a self-contained shell test suite that exercises the realm end-to-end using `gnokey`. It creates a temporary keybase, imports the `test1` funder key, generates fresh alice/bob keys, funds them if needed, and runs through the main flows (post, reply, reaction, follow, home feed, unfollow).
+
+**Prerequisites:** `gnokey` must be in your `PATH` and the target chain must be running with the realm deployed.
+
+**Run against a local gnodev instance** (default):
+
+    ./realm/tests/test.sh
+
+**Run against a remote chain** — override any of these environment variables:
+
+| Variable    | Default                   | Description         |
+| ----------- | ------------------------- | ------------------- |
+| `CHAIN_ID`  | `dev`                     | Chain ID            |
+| `NODE_ADDR` | `http://localhost:26657`  | RPC endpoint        |
+| `PKG_PATH`  | `gno.land/r/berty/social` | Deployed realm path |
+
+Example for test12:
+
+    CHAIN_ID=test12 \
+    NODE_ADDR=http://test12.example.org:26657 \
+    PKG_PATH=gno.land/r/<your-address>/social \
+    ./realm/tests/test.sh

--- a/realm/post.gno
+++ b/realm/post.gno
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"gno.land/p/moul/txlink"
-	"gno.land/p/nt/avl"
-	"gno.land/p/nt/ufmt"
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/ufmt/v0"
 )
 
 //----------------------------------------

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -4,9 +4,8 @@ import (
 	"chain/runtime"
 	"strconv"
 
-	"gno.land/p/jefft0/avlhelpers"
-	"gno.land/p/nt/avl"
-	"gno.land/p/nt/ufmt"
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/ufmt/v0"
 	"gno.land/r/sys/users"
 )
 
@@ -21,12 +20,7 @@ type UserAndPostID struct {
 // (This is similar to boards.CreateThread, but no message title)
 func PostMessage(_ realm, body string) PostID {
 	caller := runtime.OriginCaller()
-	name := usernameOf(caller)
-	if name == "" {
-		panic("please register")
-	}
-
-	userPosts := getOrCreateUserPosts(caller, name)
+	userPosts := getOrCreateUserPosts(caller, usernameOf(caller))
 	thread := userPosts.AddThread(body)
 	return thread.id
 }
@@ -39,9 +33,6 @@ func PostMessage(_ realm, body string) PostID {
 // (This is similar to boards.CreateReply.)
 func PostReply(_ realm, userPostsAddr address, threadid, postid PostID, body string) PostID {
 	caller := runtime.OriginCaller()
-	if usernameOf(caller) == "" {
-		panic("please register")
-	}
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")
@@ -73,11 +64,7 @@ func RepostThread(_ realm, userPostsAddr address, threadid PostID, comment strin
 		panic("Cannot repost a user's own message")
 	}
 
-	name := usernameOf(caller)
-	if name == "" {
-		panic("please register")
-	}
-	dstUserPosts := getOrCreateUserPosts(caller, name)
+	dstUserPosts := getOrCreateUserPosts(caller, usernameOf(caller))
 
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
@@ -226,28 +213,18 @@ func GetJsonHomePosts(userPostsAddr address, startIndex int, endIndex int) strin
 // Update the caller to follow the user with followedAddr. See UserPosts.Follow.
 func Follow(_ realm, followedAddr address) PostID {
 	caller := runtime.OriginCaller()
-	name := usernameOf(caller)
-	if name == "" {
-		panic("please register")
-	}
-
 	if followedAddr == caller {
 		panic("you can't follow yourself")
 	}
 
 	// A user can follow someone before doing any posts, so create the UserPosts if needed.
-	userPosts := getOrCreateUserPosts(caller, name)
+	userPosts := getOrCreateUserPosts(caller, usernameOf(caller))
 	return userPosts.Follow(followedAddr)
 }
 
 // Update the caller to unfollow the user with followedAddr. See UserPosts.Unfollow.
 func Unfollow(_ realm, followedAddr address) {
 	caller := runtime.OriginCaller()
-	name := usernameOf(caller)
-	if name == "" {
-		panic("please register")
-	}
-
 	userPosts := getUserPosts(caller)
 	if userPosts == nil {
 		// We don't expect this, but just do nothing.
@@ -265,9 +242,6 @@ func Unfollow(_ realm, followedAddr address) {
 // Return a boolean indicating whether the userAddr was added. See Post.AddReaction.
 func AddReaction(_ realm, userPostsAddr address, threadid, postid PostID, reaction Reaction) bool {
 	caller := runtime.OriginCaller()
-	if usernameOf(caller) == "" {
-		panic("please register")
-	}
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")
@@ -295,9 +269,6 @@ func AddReaction(_ realm, userPostsAddr address, threadid, postid PostID, reacti
 // Return a boolean indicating whether the userAddr was removed. See Post.RemoveReaction.
 func RemoveReaction(_ realm, userPostsAddr address, threadid, postid PostID, reaction Reaction) bool {
 	caller := runtime.OriginCaller()
-	if usernameOf(caller) == "" {
-		panic("please register")
-	}
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")
@@ -416,7 +387,7 @@ func GetJsonFollowing(address address, startIndex int, endIndex int) string {
 // Get a list of user names starting from the given prefix. Limit the
 // number of results to maxResults.
 func ListUsersByPrefix(prefix string, maxResults int) []string {
-	return avlhelpers.ListByteStringKeysByPrefix(&gUserAddressByName, prefix, maxResults)
+	return listByteStringKeysByPrefix(&gUserAddressByName, prefix, maxResults)
 }
 
 // Get a list of user names starting from the given prefix. Limit the

--- a/realm/render.gno
+++ b/realm/render.gno
@@ -7,13 +7,24 @@ import (
 	"gno.land/r/sys/users"
 )
 
+// resolveAddr looks up an address by registered name first, then falls back
+// to treating the input as a raw address. This allows unregistered users to
+// be found by their address string.
+func resolveAddr(nameOrAddr string) address {
+	user, _ := users.ResolveName(nameOrAddr)
+	if user != nil {
+		return user.Addr()
+	}
+	return address(nameOrAddr)
+}
+
 func Render(path string) string {
 	if path == "" {
 		str := "Welcome to dSocial!\n\n"
 
 		// List the users who have posted. gUserAddressByName is already sorted by name.
 		gUserAddressByName.Iterate("", "", func(name string, value interface{}) bool {
-			str += " * [@" + name + "](/r/berty/social:" + name + ")" + "\n"
+			str += " * [@" + name + "](" + gRealmPath + ":" + name + ")" + "\n"
 			return false
 		})
 
@@ -22,40 +33,32 @@ func Render(path string) string {
 
 	parts := strings.Split(path, "/")
 	if len(parts) == 1 {
-		// /r/berty/social:USER_NAME
-		user, _ := users.ResolveName(path)
-		if user == nil {
-			return "Unknown user: " + path
-		}
-
-		userPosts := getUserPosts(user.Addr())
+		// /r/berty/social:USER_NAME_OR_ADDR
+		userAddr := resolveAddr(path)
+		userPosts := getUserPosts(userAddr)
 		if userPosts == nil {
 			return "No posts by: " + path
 		}
 
 		return userPosts.RenderUserPosts(false)
 	} else if len(parts) == 2 {
-		name := parts[0]
-		user, _ := users.ResolveName(name)
-		if user == nil {
-			return "Unknown user: " + name
-		}
-		userPosts := getUserPosts(user.Addr())
+		userAddr := resolveAddr(parts[0])
+		userPosts := getUserPosts(userAddr)
 		if userPosts == nil {
-			return "No posts by: " + name
+			return "No posts by: " + parts[0]
 		}
 
 		if parts[1] == "home" {
-			// /r/berty/social:USER_NAME/home
+			// /r/berty/social:USER_NAME_OR_ADDR/home
 			return userPosts.RenderUserPosts(true)
 		} else if parts[1] == "followers" {
-			// /r/berty/social:USER_NAME/followers
+			// /r/berty/social:USER_NAME_OR_ADDR/followers
 			return userPosts.RenderFollowers()
 		} else if parts[1] == "following" {
-			// /r/berty/social:USER_NAME/following
+			// /r/berty/social:USER_NAME_OR_ADDR/following
 			return userPosts.RenderFollowing()
 		} else {
-			// /r/berty/social:USER_NAME/THREAD_ID
+			// /r/berty/social:USER_NAME_OR_ADDR/THREAD_ID
 			pid, err := strconv.Atoi(parts[1])
 			if err != nil {
 				return "invalid thread id: " + parts[1]
@@ -67,15 +70,11 @@ func Render(path string) string {
 			return thread.RenderPost("", 5)
 		}
 	} else if len(parts) == 3 {
-		// /r/berty/social:USER_NAME/THREAD_ID/REPLY_ID
-		name := parts[0]
-		user, _ := users.ResolveName(name)
-		if user == nil {
-			return "Unknown user: " + name
-		}
-		userPosts := getUserPosts(user.Addr())
+		// /r/berty/social:USER_NAME_OR_ADDR/THREAD_ID/REPLY_ID
+		userAddr := resolveAddr(parts[0])
+		userPosts := getUserPosts(userAddr)
 		if userPosts == nil {
-			return "No posts by: " + name
+			return "No posts by: " + parts[0]
 		}
 		pid, err := strconv.Atoi(parts[1])
 		if err != nil {

--- a/realm/social.gno
+++ b/realm/social.gno
@@ -1,11 +1,28 @@
 package social
 
 import (
-	"gno.land/p/nt/avl"
+	"strings"
+
+	"chain/runtime"
+
+	"gno.land/p/nt/avl/v0"
 )
 
 var (
 	gUserPostsByAddress avl.Tree // user's address -> *UserPosts
 	gUserAddressByName  avl.Tree // user's username -> address
 	postsCtr            uint64   // increments Post.id globally
+
+	// gRealmPath is the realm's relative URL path (e.g. "/r/g1.../social"),
+	// derived from the deployed package path at init time.
+	gRealmPath string
 )
+
+func init() {
+	pkgPath := runtime.CurrentRealm().PkgPath()
+	// Strip the chain domain (everything before the first "/") to get the
+	// relative path suitable for markdown links: "/r/g1.../social".
+	if idx := strings.Index(pkgPath, "/"); idx >= 0 {
+		gRealmPath = pkgPath[idx:]
+	}
+}

--- a/realm/tests/env.sh
+++ b/realm/tests/env.sh
@@ -52,7 +52,8 @@ generate_key() {
             --nobackup \
             "$name" 2>&1)
     # Parse: "* name (local) - addr: g1xxx pub: ..."
-    echo "$out" | grep -oE 'addr: g1[a-z0-9]+' | awk '{print $2}'
+    # Use || true so a grep non-match (no addr line) doesn't trigger set -e.
+    echo "$out" | grep -oE 'addr: g1[a-z0-9]+' | awk '{print $2}' || true
 }
 
 # ── Register helper ───────────────────────────────────────────────────────────

--- a/realm/tests/env.sh
+++ b/realm/tests/env.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Shared config and helpers for realm integration tests.
+# Source this file; do not execute it directly.
+# GNOHOME must be exported before sourcing.
+
+# ── Chain config ──────────────────────────────────────────────────────────────
+CHAIN_ID="${CHAIN_ID:-dev}"
+NODE_ADDR="${NODE_ADDR:-http://localhost:26657}"
+PKG_PATH="${PKG_PATH:-gno.land/r/berty/social}"
+GAS_FEE="${GAS_FEE:-1000000ugnot}"
+GAS_WANTED="${GAS_WANTED:-10000000}"
+GNOKEY="${GNOKEY:-gnokey}"
+
+# ── Funder key (fixed — must exist on the chain with enough GNOT) ─────────────
+TEST1_NAME="test1"
+TEST1_MNEMONIC="source bonus chronic canvas draft south burst lottery vacant surface solve popular case indicate oppose farm nothing bullet exhibit title speed wink action roast"
+TEST1_ADDR="g1jg8mtutu9khhfwc4nxmuhcpftf0pajdhfvsqf5"
+
+# ── Per-run test users ────────────────────────────────────────────────────────
+# Fresh keys are generated each run so names never collide on a persistent chain.
+RUN_ID="${RUN_ID:-$(date +%s)}"
+ALICE_NAME="alice${RUN_ID}"
+BOB_NAME="bob${RUN_ID}"
+# ALICE_ADDR and BOB_ADDR are set by test.sh after generate_key() calls.
+
+# Keybase password (only protects the local keybase file — not a real secret).
+KB_PASS="testpass"
+
+# ── Key helpers ───────────────────────────────────────────────────────────────
+
+# Import a fixed key from a mnemonic.
+# Usage: import_key <name> <mnemonic>
+import_key() {
+    local name="$1" mnemonic="$2"
+    printf "%s\n%s\n%s\n" "$mnemonic" "$KB_PASS" "$KB_PASS" \
+        | "$GNOKEY" add \
+            --home "$GNOHOME" \
+            --insecure-password-stdin \
+            --recover \
+            "$name" 2>&1
+}
+
+# Generate a fresh random key and print its address on stdout.
+# Usage: ADDR=$(generate_key <name>)
+generate_key() {
+    local name="$1"
+    local out
+    out=$(printf "%s\n%s\n" "$KB_PASS" "$KB_PASS" \
+        | "$GNOKEY" add \
+            --home "$GNOHOME" \
+            --insecure-password-stdin \
+            --nobackup \
+            "$name" 2>&1)
+    # Parse: "* name (local) - addr: g1xxx pub: ..."
+    echo "$out" | grep -oE 'addr: g1[a-z0-9]+' | awk '{print $2}'
+}
+
+# ── Register helper ───────────────────────────────────────────────────────────
+# Register a (name, address) pair in r/sys/users via r/sys/users/init.
+# On dev chains, r/sys/users/init is automatically whitelisted as a controller.
+# Usage: register <name> <address>
+register() {
+    local name="$1" addr="$2"
+    echo "$KB_PASS" \
+        | "$GNOKEY" maketx call \
+            --home      "$GNOHOME" \
+            --pkgpath   "gno.land/r/sys/users/init" \
+            --func      "RegisterUser" \
+            --args      "$name" \
+            --args      "$addr" \
+            --gas-fee   "$GAS_FEE" \
+            --gas-wanted "$GAS_WANTED" \
+            --broadcast \
+            --chainid   "$CHAIN_ID" \
+            --remote    "$NODE_ADDR" \
+            --insecure-password-stdin \
+            "$TEST1_NAME"
+}
+
+# ── Balance helper ────────────────────────────────────────────────────────────
+# Return the ugnot balance of an address (0 if account does not exist).
+# Usage: balance_ugnot <address>
+balance_ugnot() {
+    local addr="$1"
+    "$GNOKEY" query auth/accounts/"$addr" \
+        --remote "$NODE_ADDR" 2>/dev/null \
+        | grep -oE '"coins": "[0-9]+ugnot"' \
+        | grep -oE '[0-9]+' \
+        || echo 0
+}
+
+# ── Fund helper ───────────────────────────────────────────────────────────────
+# Send GNOT from test1 to an address to activate it on-chain.
+# Usage: fund <to-address> [amount]
+fund() {
+    local to="$1" amount="${2:-10000000ugnot}"
+    echo "$KB_PASS" \
+        | "$GNOKEY" maketx send \
+            --home      "$GNOHOME" \
+            --to        "$to" \
+            --send      "$amount" \
+            --gas-fee   "$GAS_FEE" \
+            --gas-wanted "$GAS_WANTED" \
+            --broadcast \
+            --chainid   "$CHAIN_ID" \
+            --remote    "$NODE_ADDR" \
+            --insecure-password-stdin \
+            "$TEST1_NAME"
+}
+
+# ── Transaction helper ────────────────────────────────────────────────────────
+# Broadcast a call transaction.
+# Usage: tx <FuncName> <key-name> [--args val ...]
+tx() {
+    local func="$1" key="$2"; shift 2
+    echo "$KB_PASS" \
+        | "$GNOKEY" maketx call \
+            --home      "$GNOHOME" \
+            --pkgpath   "$PKG_PATH" \
+            --func      "$func" \
+            --gas-fee   "$GAS_FEE" \
+            --gas-wanted "$GAS_WANTED" \
+            --broadcast \
+            --chainid   "$CHAIN_ID" \
+            --remote    "$NODE_ADDR" \
+            --insecure-password-stdin \
+            "$@" \
+            "$key"
+}
+
+# ── Query helpers ─────────────────────────────────────────────────────────────
+# vm/qeval — call a pure/view function.
+# Usage: qeval "FuncName(\"arg\")"
+qeval() {
+    "$GNOKEY" query vm/qeval \
+        --remote "$NODE_ADDR" \
+        --data   "${PKG_PATH}.$1"
+}
+
+# vm/qrender — render a path.
+# Usage: qrender "alice/home"
+qrender() {
+    "$GNOKEY" query vm/qrender \
+        --remote "$NODE_ADDR" \
+        --data   "${PKG_PATH}:$1"
+}
+
+# ── Parsing helper ────────────────────────────────────────────────────────────
+# Extract the uint from a gnokey return value like "(3 gno.land/r/.../PostID)".
+# Usage: parse_uint "$(tx ...)"
+parse_uint() {
+    echo "$1" | grep -oE '^\([0-9]+' | tr -d '('
+}
+
+# ── Assertion helpers ─────────────────────────────────────────────────────────
+FAILURES=0
+
+ok()   { echo "  [OK]   $*"; }
+fail() { echo "  [FAIL] $*" >&2; FAILURES=$((FAILURES + 1)); }
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        ok "$label"
+    else
+        fail "$label — expected to find: $needle"
+        echo "       output was: $haystack" >&2
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        fail "$label — expected NOT to find: $needle"
+        echo "       output was: $haystack" >&2
+    else
+        ok "$label"
+    fi
+}

--- a/realm/tests/test.sh
+++ b/realm/tests/test.sh
@@ -27,14 +27,17 @@ echo ""
 # ── Setup: import funder key ──────────────────────────────────────────────────
 echo "--- Setup: importing keys ---"
 
-import_key "$TEST1_NAME" "$TEST1_MNEMONIC" > /dev/null
+OUT=$(import_key "$TEST1_NAME" "$TEST1_MNEMONIC") \
+    || { echo "[FAIL] could not import test1 key: $OUT" >&2; exit 1; }
 ok "test1 imported  ($TEST1_ADDR)"
 
-ALICE_ADDR=$(generate_key "$ALICE_NAME")
+ALICE_ADDR=$(generate_key "$ALICE_NAME") \
+    || { echo "[FAIL] could not generate alice key" >&2; exit 1; }
 [ -n "$ALICE_ADDR" ] && ok "alice generated ($ALICE_ADDR) as $ALICE_NAME" \
                      || { echo "[FAIL] could not generate alice key" >&2; exit 1; }
 
-BOB_ADDR=$(generate_key "$BOB_NAME")
+BOB_ADDR=$(generate_key "$BOB_NAME") \
+    || { echo "[FAIL] could not generate bob key" >&2; exit 1; }
 [ -n "$BOB_ADDR" ]   && ok "bob generated   ($BOB_ADDR) as $BOB_NAME" \
                      || { echo "[FAIL] could not generate bob key" >&2; exit 1; }
 

--- a/realm/tests/test.sh
+++ b/realm/tests/test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Integration tests for gno.land/r/berty/social.
+#
+# Usage:
+#   ./test.sh
+#   CHAIN_ID=dev NODE_ADDR=http://localhost:26657 ./test.sh
+#
+# Each run generates fresh alice/bob keys with unique names so it is safe to
+# run multiple times against a persistent chain without name collisions.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Isolated keybase in a tmp directory; cleaned up on exit.
+GNOHOME=$(mktemp -d)
+export GNOHOME
+trap 'rm -rf "$GNOHOME"' EXIT
+
+source env.sh
+
+echo "=== dSocial realm tests ==="
+echo "    chain:  $CHAIN_ID @ $NODE_ADDR"
+echo "    run id: $RUN_ID"
+echo "    home:   $GNOHOME"
+echo ""
+
+# ── Setup: import funder key ──────────────────────────────────────────────────
+echo "--- Setup: importing keys ---"
+
+import_key "$TEST1_NAME" "$TEST1_MNEMONIC" > /dev/null
+ok "test1 imported  ($TEST1_ADDR)"
+
+ALICE_ADDR=$(generate_key "$ALICE_NAME")
+[ -n "$ALICE_ADDR" ] && ok "alice generated ($ALICE_ADDR) as $ALICE_NAME" \
+                     || { echo "[FAIL] could not generate alice key" >&2; exit 1; }
+
+BOB_ADDR=$(generate_key "$BOB_NAME")
+[ -n "$BOB_ADDR" ]   && ok "bob generated   ($BOB_ADDR) as $BOB_NAME" \
+                     || { echo "[FAIL] could not generate bob key" >&2; exit 1; }
+
+echo ""
+
+# ── Setup: fund accounts ──────────────────────────────────────────────────────
+# Minimum balance required to cover gas for all transactions in the suite.
+MIN_BALANCE=5000000   # 5 GNOT in ugnot
+
+echo "--- Setup: funding accounts ---"
+
+BAL=$(balance_ugnot "$ALICE_ADDR")
+if [ "${BAL:-0}" -lt "$MIN_BALANCE" ]; then
+    OUT=$(fund "$ALICE_ADDR")
+    assert_contains "alice funded" "$OUT" "OK"
+else
+    ok "alice already has sufficient funds (${BAL}ugnot)"
+fi
+
+BAL=$(balance_ugnot "$BOB_ADDR")
+if [ "${BAL:-0}" -lt "$MIN_BALANCE" ]; then
+    OUT=$(fund "$BOB_ADDR")
+    assert_contains "bob funded" "$OUT" "OK"
+else
+    ok "bob already has sufficient funds (${BAL}ugnot)"
+fi
+
+echo ""
+
+# ── 1. PostMessage ────────────────────────────────────────────────────────────
+echo "--- 1. PostMessage ---"
+
+OUT=$(tx PostMessage "$ALICE_NAME" --args "Hello from the test suite!")
+echo "$OUT"
+assert_contains "PostMessage succeeds" "$OUT" "OK"
+THREAD_ID=$(parse_uint "$OUT")
+[ -n "$THREAD_ID" ] && ok "thread id = $THREAD_ID" || fail "could not parse thread id"
+
+echo ""
+
+# ── 2. Render user page ───────────────────────────────────────────────────────
+echo "--- 2. Render user page ---"
+
+OUT=$(qrender "$ALICE_ADDR")
+echo "$OUT"
+assert_contains "post visible in render" "$OUT" "Hello from the test suite"
+
+echo ""
+
+
+# ── 4. GetJsonUserPostsInfo ───────────────────────────────────────────────────
+echo "--- 4. GetJsonUserPostsInfo ---"
+
+OUT=$(qeval "GetJsonUserPostsInfo(address(\"$ALICE_ADDR\"))")
+echo "$OUT"
+assert_contains "returns n_threads" "$OUT" 'n_threads'
+
+echo ""
+
+# ── 5. PostReply ──────────────────────────────────────────────────────────────
+echo "--- 5. PostReply ---"
+
+OUT=$(tx PostReply "$BOB_NAME" \
+    --args "$ALICE_ADDR" \
+    --args "$THREAD_ID" \
+    --args "$THREAD_ID" \
+    --args "Nice post!")
+echo "$OUT"
+assert_contains "PostReply succeeds" "$OUT" "OK"
+REPLY_ID=$(parse_uint "$OUT")
+[ -n "$REPLY_ID" ] && ok "reply id = $REPLY_ID" || fail "could not parse reply id"
+
+echo ""
+
+# ── 6. AddReaction ────────────────────────────────────────────────────────────
+echo "--- 6. AddReaction (gnod) ---"
+
+OUT=$(tx AddReaction "$BOB_NAME" \
+    --args "$ALICE_ADDR" \
+    --args "$THREAD_ID" \
+    --args "$THREAD_ID" \
+    --args "0")
+echo "$OUT"
+assert_contains "AddReaction succeeds" "$OUT" "OK"
+
+echo ""
+
+# ── 7. Follow ─────────────────────────────────────────────────────────────────
+echo "--- 7. Follow ---"
+
+OUT=$(tx Follow "$BOB_NAME" --args "$ALICE_ADDR")
+echo "$OUT"
+assert_contains "Follow succeeds" "$OUT" "OK"
+
+OUT=$(qeval "GetJsonFollowers(address(\"$ALICE_ADDR\"), 0, 10)")
+echo "$OUT"
+assert_contains "bob in alice's followers" "$OUT" "$BOB_ADDR"
+
+echo ""
+
+# ── 8. RefreshHomePosts ───────────────────────────────────────────────────────
+# refreshHomePosts only picks up posts made AFTER the follow, so alice posts
+# a second message here before bob refreshes.
+echo "--- 8. RefreshHomePosts ---"
+
+OUT=$(tx PostMessage "$ALICE_NAME" --args "Second post after follow!")
+echo "$OUT"
+assert_contains "alice second post succeeds" "$OUT" "OK"
+
+OUT=$(tx RefreshHomePosts "$BOB_NAME" --args "$BOB_ADDR")
+echo "$OUT"
+assert_contains "RefreshHomePosts succeeds" "$OUT" "OK"
+
+OUT=$(qeval "GetJsonHomePosts(address(\"$BOB_ADDR\"), 0, 5)")
+echo "$OUT"
+assert_contains "alice's post in bob's home feed" "$OUT" "Second post after follow"
+
+echo ""
+
+# ── 9. Unfollow ───────────────────────────────────────────────────────────────
+echo "--- 9. Unfollow ---"
+
+OUT=$(tx Unfollow "$BOB_NAME" --args "$ALICE_ADDR")
+echo "$OUT"
+assert_contains "Unfollow succeeds" "$OUT" "OK"
+
+OUT=$(qeval "GetJsonFollowers(address(\"$ALICE_ADDR\"), 0, 10)")
+echo "$OUT"
+assert_not_contains "bob no longer in alice's followers" "$OUT" "$BOB_ADDR"
+
+echo ""
+
+# ── 10. ListJsonUsersByPrefix ─────────────────────────────────────────────────
+echo "--- 10. ListJsonUsersByPrefix ---"
+
+OUT=$(qeval "ListJsonUsersByPrefix(\"\", 20)")
+echo "$OUT"
+assert_contains "returns a JSON list"       "$OUT" "["
+assert_contains "alice appears in results"  "$OUT" "$ALICE_ADDR"
+
+echo ""
+
+# ── Result ────────────────────────────────────────────────────────────────────
+if [ "$FAILURES" -eq 0 ]; then
+    echo "=== All tests passed ==="
+else
+    echo "=== $FAILURES test(s) FAILED ===" >&2
+    exit 1
+fi

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"gno.land/p/moul/txlink"
-	"gno.land/p/nt/avl"
-	"gno.land/p/nt/ufmt"
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/ufmt/v0"
 	"gno.land/r/sys/users"
 )
 
@@ -114,8 +114,8 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	following := "Following " + strconv.Itoa(userPosts.following.Size())
 	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
-		followers = "[" + followers + "](/r/berty/social:" + user.Name() + "/followers)"
-		following = "[" + following + "](/r/berty/social:" + user.Name() + "/following)"
+		followers = "[" + followers + "](" + gRealmPath + ":" + user.Name() + "/followers)"
+		following = "[" + following + "](" + gRealmPath + ":" + user.Name() + "/following)"
 	}
 	str += followers + " &nbsp;" + following + "\n\n"
 
@@ -144,7 +144,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 	str := ""
 	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
-		str += "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ") "
+		str += "[@" + user.Name() + "](" + gRealmPath + ":" + user.Name() + ") "
 	}
 	str += "Followers\n\n"
 
@@ -158,7 +158,7 @@ func (userPosts *UserPosts) RenderFollowers() string {
 	})
 	sort.Strings(names)
 	for _, name := range names {
-		str += " * [@" + name + "](/r/berty/social:" + name + ")" + "\n"
+		str += " * [@" + name + "](" + gRealmPath + ":" + name + ")" + "\n"
 	}
 
 	return str
@@ -168,7 +168,7 @@ func (userPosts *UserPosts) RenderFollowing() string {
 	str := ""
 	user := users.ResolveAddress(userPosts.userAddr)
 	if user != nil {
-		str += "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ") "
+		str += "[@" + user.Name() + "](" + gRealmPath + ":" + user.Name() + ") "
 	}
 	str += "Following\n\n"
 
@@ -187,7 +187,7 @@ func (userPosts *UserPosts) RenderFollowing() string {
 		name := parts[0]
 		addr := parts[1]
 		since := parts[2]
-		str += " * [@" + name + "](/r/berty/social:" + name + ") since " + since +
+		str += " * [@" + name + "](" + gRealmPath + ":" + name + ") since " + since +
 			"  \\[[unfollow](" + userPosts.GetUnfollowFormURL(address(addr)) + ")]\n"
 	}
 

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -113,10 +113,12 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	followers := strconv.Itoa(userPosts.followers.Size()) + " Followers"
 	following := "Following " + strconv.Itoa(userPosts.following.Size())
 	user := users.ResolveAddress(userPosts.userAddr)
+	nameOrAddr := userPosts.userAddr.String()
 	if user != nil {
-		followers = "[" + followers + "](" + gRealmPath + ":" + user.Name() + "/followers)"
-		following = "[" + following + "](" + gRealmPath + ":" + user.Name() + "/following)"
+		nameOrAddr = user.Name()
 	}
+	followers = "[" + followers + "](" + gRealmPath + ":" + nameOrAddr + "/followers)"
+	following = "[" + following + "](" + gRealmPath + ":" + nameOrAddr + "/following)"
 	str += followers + " &nbsp;" + following + "\n\n"
 
 	str += "\\[[post](" + userPosts.GetPostFormURL() + ")] \\[[follow](" + userPosts.GetFollowFormURL() + ")]"
@@ -143,16 +145,19 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 func (userPosts *UserPosts) RenderFollowers() string {
 	str := ""
 	user := users.ResolveAddress(userPosts.userAddr)
+	ownerRef := userPosts.userAddr.String()
 	if user != nil {
-		str += "[@" + user.Name() + "](" + gRealmPath + ":" + user.Name() + ") "
+		ownerRef = user.Name()
 	}
-	str += "Followers\n\n"
+	str += "[@" + ownerRef + "](" + gRealmPath + ":" + ownerRef + ") Followers\n\n"
 
-	// List the followers, sorted by name.
+	// List the followers, sorted by name/addr.
 	names := []string{}
 	userPosts.followers.Iterate("", "", func(key string, value interface{}) bool {
-		if user := users.ResolveAddress(address(key)); user != nil {
-			names = append(names, user.Name())
+		if u := users.ResolveAddress(address(key)); u != nil {
+			names = append(names, u.Name())
+		} else {
+			names = append(names, key)
 		}
 		return false
 	})
@@ -167,18 +172,21 @@ func (userPosts *UserPosts) RenderFollowers() string {
 func (userPosts *UserPosts) RenderFollowing() string {
 	str := ""
 	user := users.ResolveAddress(userPosts.userAddr)
+	ownerRef := userPosts.userAddr.String()
 	if user != nil {
-		str += "[@" + user.Name() + "](" + gRealmPath + ":" + user.Name() + ") "
+		ownerRef = user.Name()
 	}
-	str += "Following\n\n"
+	str += "[@" + ownerRef + "](" + gRealmPath + ":" + ownerRef + ") Following\n\n"
 
 	// List the following, sorted by name/addr.
 	nameAddrs := []string{}
 	userPosts.following.Iterate("", "", func(addr string, infoI interface{}) bool {
 		info := infoI.(*FollowingInfo)
-		if user := users.ResolveAddress(address(addr)); user != nil {
-			nameAddrs = append(nameAddrs, user.Name()+"/"+addr+"/"+info.startedFollowingAt.Format("2006-01-02"))
+		ref := addr
+		if u := users.ResolveAddress(address(addr)); u != nil {
+			ref = u.Name()
 		}
+		nameAddrs = append(nameAddrs, ref+"/"+addr+"/"+info.startedFollowingAt.Format("2006-01-02"))
 		return false
 	})
 	sort.Strings(nameAddrs)

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"gno.land/p/nt/avl"
-	"gno.land/p/nt/ufmt"
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/ufmt/v0"
 	"gno.land/r/sys/users"
 )
 
@@ -33,13 +33,13 @@ func getOrCreateUserPosts(userAddr address, username string) *UserPosts {
 	}
 
 	if username == "" {
-		username := usernameOf(userAddr)
-		if username == "" {
-			panic("no username for address " + userAddr.String())
-		}
+		username = usernameOf(userAddr)
+	}
+	if username == "" {
+		username = userAddr.String()
 	}
 
-	userPosts = newUserPosts("/r/berty/social:"+username, userAddr)
+	userPosts = newUserPosts(gRealmPath+":"+username, userAddr)
 	gUserPostsByAddress.Set(userAddr.String(), userPosts)
 	gUserAddressByName.Set(username, userAddr)
 
@@ -77,6 +77,27 @@ func getOrCreateReactionValue(reactions *avl.Tree, reaction Reaction) *avl.Tree 
 	}
 }
 
+// listByteStringKeysByPrefix returns up to maxResults keys from tree that start
+// with the given prefix, treating keys as byte strings (not Unicode runes).
+// Inlined from gno.land/p/jefft0/avlhelpers which is not yet deployed.
+func listByteStringKeysByPrefix(tree avl.ITree, prefix string, maxResults int) []string {
+	result := []string{}
+	end := ""
+	n := len(prefix)
+	for n > 0 {
+		if ascii := int(prefix[n-1]); ascii < 0xff {
+			end = prefix[0:n-1] + string(ascii+1)
+			break
+		}
+		n--
+	}
+	tree.Iterate(prefix, end, func(key string, value any) bool {
+		result = append(result, key)
+		return len(result) >= maxResults
+	})
+	return result
+}
+
 func indentBody(indent string, body string) string {
 	lines := strings.Split(body, "\n")
 	res := ""
@@ -107,7 +128,7 @@ func displayAddressMD(addr address) string {
 	if user == nil {
 		return "[" + addr.String() + "](/r/gnoland/users/v1:" + addr.String() + ")"
 	} else {
-		return "[@" + user.Name() + "](/r/berty/social:" + user.Name() + ")"
+		return "[@" + user.Name() + "](" + gRealmPath + ":" + user.Name() + ")"
 	}
 }
 

--- a/tools/notification-service/go.mod
+++ b/tools/notification-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/gnoverse/dsocial/tools/notification-service
 
-go 1.21.7
+go 1.24
 
 require (
 	buf.build/gen/go/gnolang/dsocial-indexer/connectrpc/go v1.17.0-20241114144551-3a1c1a1274a4.1


### PR DESCRIPTION
- Update package imports: p/nt/avl → p/nt/avl/v0, p/nt/ufmt → p/nt/ufmt/v0
- Remove dependency on p/jefft0/avlhelpers (not deployed on gnoland/test12); inline listByteStringKeysByPrefix in util.gno
- Remove r/sys/users registration requirement — unregistered users fall back to their address as username, making the realm usable on chains where the whitelist is not configured
- Add resolveAddr() in render.gno so render paths accept raw addresses, not just registered names
- Replace hardcoded /r/berty/social strings with a gRealmPath variable initialized at deploy time via runtime.CurrentRealm().PkgPath(), so rendered links are always correct regardless of deployment path