### PR TITLE
chore: replace avl tree by bptree

### DIFF
--- a/.github/workflows/realm-tests.yml
+++ b/.github/workflows/realm-tests.yml
@@ -25,7 +25,7 @@ jobs:
           repository: gnolang/gno
           # Pin to the gno version this realm was developed against.
           # Update this ref when bumping gno compatibility.
-          ref: 2efd147d9124e29a57146913d93a3e1f983e083d
+          ref: d8a351e7509ce945267b0d929ead44b981b4061b
           path: .gno
 
       - name: Cache Go build

--- a/realm/post.gno
+++ b/realm/post.gno
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"gno.land/p/moul/txlink"
-	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/bptree/v0"
 	"gno.land/p/nt/ufmt/v0"
 )
 
@@ -36,13 +36,13 @@ type Post struct {
 	id         PostID
 	creator    address
 	body       string
-	replies    avl.Tree  // PostID -> *Post
-	repliesAll avl.Tree  // PostID -> *Post (all replies, for top-level posts)
-	reposts    avl.Tree  // UserPosts user address -> PostID
-	threadID   PostID    // original PostID
-	parentID   PostID    // parent PostID (if reply or repost)
-	repostUser address   // UserPosts user address of original post (if repost)
-	reactions  *avl.Tree // Reaction -> *avl.Tree of address -> "" (Use the avl.Tree keys as the "set" of addresses)
+	replies    bptree.BPTree  // PostID -> *Post
+	repliesAll bptree.BPTree  // PostID -> *Post (all replies, for top-level posts)
+	reposts    bptree.BPTree  // UserPosts user address -> PostID
+	threadID   PostID         // original PostID
+	parentID   PostID         // parent PostID (if reply or repost)
+	repostUser address        // UserPosts user address of original post (if repost)
+	reactions  *bptree.BPTree // Reaction -> *bptree.BPTree of address -> "" (Use the bptree.BPTree keys as the "set" of addresses)
 	createdAt  time.Time
 }
 
@@ -52,13 +52,13 @@ func newPost(userPosts *UserPosts, id PostID, creator address, body string, thre
 		id:         id,
 		creator:    creator,
 		body:       body,
-		replies:    avl.Tree{},
-		repliesAll: avl.Tree{},
-		reposts:    avl.Tree{},
+		replies:    bptree.BPTree{},
+		repliesAll: bptree.BPTree{},
+		reposts:    bptree.BPTree{},
 		threadID:   threadID,
 		parentID:   parentID,
 		repostUser: repostUser,
-		reactions:  avl.NewTree(),
+		reactions:  bptree.NewBPTree32(),
 		createdAt:  time.Now(),
 	}
 }
@@ -153,7 +153,7 @@ func (post *Post) GetReactionCount(reaction Reaction) int {
 	key := reactionKey(reaction)
 	valueI, exists := post.reactions.Get(key)
 	if exists {
-		return valueI.(*avl.Tree).Size()
+		return valueI.(*bptree.BPTree).Size()
 	} else {
 		return 0
 	}
@@ -299,7 +299,7 @@ func (post *Post) MarshalJSON() ([]byte, error) {
 	return json.Bytes(), nil
 }
 
-func getPosts(posts avl.Tree, startIndex int, endIndex int) string {
+func getPosts(posts bptree.BPTree, startIndex int, endIndex int) string {
 	json := ufmt.Sprintf("{\"n_threads\": %d, \"posts\": [\n  ", posts.Size())
 
 	for i := startIndex; i < endIndex && i < posts.Size(); i++ {

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -1,7 +1,6 @@
 package social
 
 import (
-	"chain/runtime"
 	"strconv"
 
 	"gno.land/p/nt/bptree/v0"
@@ -18,8 +17,8 @@ type UserAndPostID struct {
 // The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return the "thread ID" of the new post.
 // (This is similar to boards.CreateThread, but no message title)
-func PostMessage(_ realm, body string) PostID {
-	caller := runtime.OriginCaller()
+func PostMessage(cur realm, body string) PostID {
+	caller := cur.Previous().Address()
 	userPosts := getOrCreateUserPosts(caller, usernameOf(caller))
 	thread := userPosts.AddThread(body)
 	return thread.id
@@ -31,8 +30,8 @@ func PostMessage(_ realm, body string) PostID {
 // The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return the new post ID.
 // (This is similar to boards.CreateReply.)
-func PostReply(_ realm, userPostsAddr address, threadid, postid PostID, body string) PostID {
-	caller := runtime.OriginCaller()
+func PostReply(cur realm, userPostsAddr address, threadid, postid PostID, body string) PostID {
+	caller := cur.Previous().Address()
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")
@@ -58,8 +57,8 @@ func PostReply(_ realm, userPostsAddr address, threadid, postid PostID, body str
 // the original call to PostMessage. This must be a top-level thread (not a reply).
 // Return the new post ID.
 // (This is similar to boards.CreateRepost.)
-func RepostThread(_ realm, userPostsAddr address, threadid PostID, comment string) PostID {
-	caller := runtime.OriginCaller()
+func RepostThread(cur realm, userPostsAddr address, threadid PostID, comment string) PostID {
+	caller := cur.Previous().Address()
 	if userPostsAddr == caller {
 		panic("Cannot repost a user's own message")
 	}
@@ -211,8 +210,8 @@ func GetJsonHomePosts(userPostsAddr address, startIndex int, endIndex int) strin
 }
 
 // Update the caller to follow the user with followedAddr. See UserPosts.Follow.
-func Follow(_ realm, followedAddr address) PostID {
-	caller := runtime.OriginCaller()
+func Follow(cur realm, followedAddr address) PostID {
+	caller := cur.Previous().Address()
 	if followedAddr == caller {
 		panic("you can't follow yourself")
 	}
@@ -223,8 +222,8 @@ func Follow(_ realm, followedAddr address) PostID {
 }
 
 // Update the caller to unfollow the user with followedAddr. See UserPosts.Unfollow.
-func Unfollow(_ realm, followedAddr address) {
-	caller := runtime.OriginCaller()
+func Unfollow(cur realm, followedAddr address) {
+	caller := cur.Previous().Address()
 	userPosts := getUserPosts(caller)
 	if userPosts == nil {
 		// We don't expect this, but just do nothing.
@@ -240,8 +239,8 @@ func Unfollow(_ realm, followedAddr address) {
 // (This function's arguments are similar to PostReply.)
 // The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return a boolean indicating whether the userAddr was added. See Post.AddReaction.
-func AddReaction(_ realm, userPostsAddr address, threadid, postid PostID, reaction Reaction) bool {
-	caller := runtime.OriginCaller()
+func AddReaction(cur realm, userPostsAddr address, threadid, postid PostID, reaction Reaction) bool {
+	caller := cur.Previous().Address()
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")
@@ -267,8 +266,8 @@ func AddReaction(_ realm, userPostsAddr address, threadid, postid PostID, reacti
 // (This function's arguments are similar to PostReply.)
 // The caller must already be registered with /r/gnoland/users/v1 Register.
 // Return a boolean indicating whether the userAddr was removed. See Post.RemoveReaction.
-func RemoveReaction(_ realm, userPostsAddr address, threadid, postid PostID, reaction Reaction) bool {
-	caller := runtime.OriginCaller()
+func RemoveReaction(cur realm, userPostsAddr address, threadid, postid PostID, reaction Reaction) bool {
+	caller := cur.Previous().Address()
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")

--- a/realm/public.gno
+++ b/realm/public.gno
@@ -4,7 +4,7 @@ import (
 	"chain/runtime"
 	"strconv"
 
-	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/bptree/v0"
 	"gno.land/p/nt/ufmt/v0"
 	"gno.land/r/sys/users"
 )
@@ -171,12 +171,12 @@ func GetHomePostsCount(userPostsAddr address) int {
 
 // Get home posts for a user, which are the user's top-level posts plus all posts of all
 // users being followed.
-// The response is a map of postID -> *Post. The avl.Tree sorts by the post ID which is
+// The response is a map of postID -> *Post. The bptree.BPTree sorts by the post ID which is
 // unique for every post and increases in time.
 // If you just want the total count, use GetHomePostsCount.
 // This returns the current state of the home posts (without need to pay gas). To include the
 // latest followed posts, call RefreshHomePosts.
-func GetHomePosts(userPostsAddr address) *avl.Tree {
+func GetHomePosts(userPostsAddr address) *bptree.BPTree {
 	userPosts := getUserPosts(userPostsAddr)
 	if userPosts == nil {
 		panic("posts for userPostsAddr do not exist")

--- a/realm/social.gno
+++ b/realm/social.gno
@@ -5,12 +5,12 @@ import (
 
 	"chain/runtime"
 
-	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/bptree/v0"
 )
 
 var (
-	gUserPostsByAddress avl.Tree // user's address -> *UserPosts
-	gUserAddressByName  avl.Tree // user's username -> address
+	gUserPostsByAddress bptree.BPTree // user's address -> *UserPosts
+	gUserAddressByName  bptree.BPTree // user's username -> address
 	postsCtr            uint64   // increments Post.id globally
 
 	// gRealmPath is the realm's relative URL path (e.g. "/r/g1.../social"),

--- a/realm/social.gno
+++ b/realm/social.gno
@@ -3,8 +3,6 @@ package social
 import (
 	"strings"
 
-	"chain/runtime"
-
 	"gno.land/p/nt/bptree/v0"
 )
 
@@ -18,8 +16,8 @@ var (
 	gRealmPath string
 )
 
-func init() {
-	pkgPath := runtime.CurrentRealm().PkgPath()
+func init(cur realm) {
+	pkgPath := cur.PkgPath()
 	// Strip the chain domain (everything before the first "/") to get the
 	// relative path suitable for markdown links: "/r/g1.../social".
 	if idx := strings.Index(pkgPath, "/"); idx >= 0 {

--- a/realm/tests/env.sh
+++ b/realm/tests/env.sh
@@ -8,7 +8,7 @@ CHAIN_ID="${CHAIN_ID:-dev}"
 NODE_ADDR="${NODE_ADDR:-http://localhost:26657}"
 PKG_PATH="${PKG_PATH:-gno.land/r/berty/social}"
 GAS_FEE="${GAS_FEE:-1000000ugnot}"
-GAS_WANTED="${GAS_WANTED:-10000000}"
+GAS_WANTED="${GAS_WANTED:-50000000}"
 GNOKEY="${GNOKEY:-gnokey}"
 
 # ── Funder key (fixed — must exist on the chain with enough GNOT) ─────────────

--- a/realm/userposts.gno
+++ b/realm/userposts.gno
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"gno.land/p/moul/txlink"
-	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/bptree/v0"
 	"gno.land/p/nt/ufmt/v0"
 	"gno.land/r/sys/users"
 )
@@ -25,11 +25,11 @@ type FollowingInfo struct {
 type UserPosts struct {
 	url           string
 	userAddr      address
-	threads       avl.Tree // PostID -> *Post
-	homePosts     avl.Tree // PostID -> *Post. Includes this user's threads posts plus posts of users being followed.
-	lastRefreshId PostID   // Updated by refreshHomePosts
-	followers     avl.Tree // address -> ""
-	following     avl.Tree // address -> *FollowingInfo
+	threads       bptree.BPTree // PostID -> *Post
+	homePosts     bptree.BPTree // PostID -> *Post. Includes this user's threads posts plus posts of users being followed.
+	lastRefreshId PostID        // Updated by refreshHomePosts
+	followers     bptree.BPTree // address -> ""
+	following     bptree.BPTree // address -> *FollowingInfo
 }
 
 // Create a new userPosts for the user. Panic if there is already a userPosts for the user.
@@ -40,11 +40,11 @@ func newUserPosts(url string, userAddr address) *UserPosts {
 	return &UserPosts{
 		url:           url,
 		userAddr:      userAddr,
-		threads:       avl.Tree{},
-		homePosts:     avl.Tree{},
+		threads:       bptree.BPTree{},
+		homePosts:     bptree.BPTree{},
 		lastRefreshId: PostID(postsCtr), // Ignore past messages of followed users.
-		followers:     avl.Tree{},
-		following:     avl.Tree{},
+		followers:     bptree.BPTree{},
+		following:     bptree.BPTree{},
 	}
 }
 
@@ -127,7 +127,7 @@ func (userPosts *UserPosts) RenderUserPosts(includeFollowed bool) string {
 	}
 	str += "\n\n"
 
-	var posts *avl.Tree
+	var posts *bptree.BPTree
 	if includeFollowed {
 		posts = &userPosts.homePosts
 	} else {
@@ -232,7 +232,7 @@ func (userPosts *UserPosts) GetRefreshFormURL() string {
 }
 
 // Scan userPosts.following for all posts from all followed users starting from lastRefreshId+1 .
-// Add the posts to the homePosts avl.Tree, which is sorted by the post ID which is unique for every post and
+// Add the posts to the homePosts bptree.BPTree, which is sorted by the post ID which is unique for every post and
 // increases in time. When finished, update lastRefreshId.
 func (userPosts *UserPosts) refreshHomePosts() {
 	minStartKey := postIDKey(userPosts.lastRefreshId + 1)

--- a/realm/util.gno
+++ b/realm/util.gno
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/bptree/v0"
 	"gno.land/p/nt/ufmt/v0"
 	"gno.land/r/sys/users"
 )
@@ -64,14 +64,14 @@ func reactionKey(reaction Reaction) string {
 }
 
 // If reactions has an value for the given reaction, then return it.
-// Otherwise, add the reaction key to reactions, set the value to an empty avl.Tree and return it.
-func getOrCreateReactionValue(reactions *avl.Tree, reaction Reaction) *avl.Tree {
+// Otherwise, add the reaction key to reactions, set the value to an empty bptree.BPTree and return it.
+func getOrCreateReactionValue(reactions *bptree.BPTree, reaction Reaction) *bptree.BPTree {
 	key := reactionKey(reaction)
 	valueI, exists := reactions.Get(key)
 	if exists {
-		return valueI.(*avl.Tree)
+		return valueI.(*bptree.BPTree)
 	} else {
-		value := avl.NewTree()
+		value := bptree.NewBPTree32()
 		reactions.Set(key, value)
 		return value
 	}
@@ -80,7 +80,7 @@ func getOrCreateReactionValue(reactions *avl.Tree, reaction Reaction) *avl.Tree 
 // listByteStringKeysByPrefix returns up to maxResults keys from tree that start
 // with the given prefix, treating keys as byte strings (not Unicode runes).
 // Inlined from gno.land/p/jefft0/avlhelpers which is not yet deployed.
-func listByteStringKeysByPrefix(tree avl.ITree, prefix string, maxResults int) []string {
+func listByteStringKeysByPrefix(tree bptree.ITree, prefix string, maxResults int) []string {
 	result := []string{}
 	end := ""
 	n := len(prefix)


### PR DESCRIPTION
The avl tree package is now deprecated since https://github.com/gnolang/gno/pull/5475. So this PR replaces it by the new bptree package that uses the same API.